### PR TITLE
Add tests for all applications and limit mechanics explorer opening.

### DIFF
--- a/Body-to-Body_Interactions/TestB2B.m
+++ b/Body-to-Body_Interactions/TestB2B.m
@@ -1,0 +1,103 @@
+classdef TestB2B < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'rm3.h5'
+        outName = 'rm3.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestB2B
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,60,[],[],[],[]);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,157,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestMethodTeardown)
+        function returnHome(testCase)
+            cd(testCase.testDir)
+        end
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testB2B_Case1(testCase)
+            cd('B2B_Case1')
+            wecSim
+        end
+        
+        function testB2B_Case2(testCase)
+            cd('B2B_Case2')
+            wecSim
+        end
+        
+        function testB2B_Case3(testCase)
+            cd('B2B_Case3')
+            wecSim
+        end
+        
+        function testB2B_Case4(testCase)
+            cd('B2B_Case4')
+            wecSim
+        end
+        
+        function testB2B_Case5(testCase)
+            cd('B2B_Case5')
+            wecSim
+        end
+        
+        function testB2B_Case6(testCase)
+            cd('B2B_Case6')
+            wecSim
+        end
+        
+    end
+    
+end

--- a/Desalination/TestDesalination.m
+++ b/Desalination/TestDesalination.m
@@ -1,0 +1,70 @@
+classdef TestDesalination < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'oswec.h5'
+        outName = 'oswec.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestDesalination
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,30,[],[],[],[]);
+            hydro = Excitation_IRF(hydro,30,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testDesalination(testCase)
+            wecSim
+        end
+        
+    end
+    
+end

--- a/Desalination/wecSimInputFile.m
+++ b/Desalination/wecSimInputFile.m
@@ -2,7 +2,7 @@
 simu = simulationClass();
 simu.simMechanicsFile = 'OSWEC_RO.slx';     % Specify Simulink Model File
 %simu.mode = 'rapid-accelerator';           % Specify Simulation Mode ('normal','accelerator','rapid-accelerator')
-simu.explorer='on';                         % Turn SimMechanics Explorer (on/off)
+simu.explorer='off';                        % Turn SimMechanics Explorer (on/off)
 simu.startTime = 0;                         % Simulation Start Time [s]
 simu.endTime=300;
 simu.solver = 'ode4';                       %simu.solver = 'ode4' for fixed step & simu.solver = 'ode45' for variable step 

--- a/End_Stops/v2019a/TestEndStops.m
+++ b/End_Stops/v2019a/TestEndStops.m
@@ -1,0 +1,71 @@
+classdef TestEndStops < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("..", "hydroData")
+        h5Name = 'rm3.h5'
+        outName = 'rm3.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestEndStops
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,60,[],[],[],[]);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,157,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testEnd_Stops(testCase)
+            wecSim
+        end
+        
+    end
+    
+end

--- a/Free_Decay/TestFreeDecay.m
+++ b/Free_Decay/TestFreeDecay.m
@@ -1,0 +1,103 @@
+classdef TestFreeDecay < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'sphere.h5'
+        outName = 'sphere.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestFreeDecay
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,15,[],[],[],[]);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,62.5,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestMethodTeardown)
+        function returnHome(testCase)
+            cd(testCase.testDir)
+        end
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testFree_Decay_0m(testCase)
+            cd('0m')
+            wecSim
+            cd(testCase.testDir)
+        end
+        
+        function testFree_Decay_1m(testCase)
+            cd('1m')
+            wecSim
+            cd(testCase.testDir)
+        end
+        
+        function testFree_Decay_1m_ME(testCase)
+            cd('1m-ME')
+            wecSim
+            cd(testCase.testDir)
+        end
+        
+        function testFree_Decay_3m(testCase)
+            cd('3m')
+            wecSim
+            cd(testCase.testDir)
+        end
+        
+        function testFree_Decay_5m(testCase)
+            cd('5m')
+            wecSim
+            cd(testCase.testDir)
+        end
+        
+    end
+    
+end

--- a/Generalized_Body_Modes/TestGeneralizedBodyModes.m
+++ b/Generalized_Body_Modes/TestGeneralizedBodyModes.m
@@ -1,0 +1,71 @@
+classdef TestGeneralizedBodyModes < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'barge.h5'
+        outName = 'WAMIT/barge.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestGeneralizedBodyModes
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,100,[],[],[],20);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,100,[],[],[],30);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testGeneralized_Body_Modes(testCase)
+            wecSim
+        end
+        
+    end
+    
+end

--- a/Mooring/TestMooring.m
+++ b/Mooring/TestMooring.m
@@ -1,0 +1,85 @@
+classdef TestMooring < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'rm3.h5'
+        outName = 'rm3.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestMooring
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,60,[],[],[],[]);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,157,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestMethodTeardown)
+        function returnHome(testCase)
+            cd(testCase.testDir)
+        end
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testMoorDyn(testCase)
+            cd MoorDyn
+            wecSim
+            cd(testCase.testDir)
+        end
+        
+        function testMooringMatrix(testCase)
+            cd MooringMatrix
+            wecSim
+            cd(testCase.testDir)
+        end
+        
+    end
+    
+end

--- a/Multiple_Condition_Runs/TestMultipleConditionRuns.m
+++ b/Multiple_Condition_Runs/TestMultipleConditionRuns.m
@@ -1,0 +1,93 @@
+classdef TestMultipleConditionRuns < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'rm3.h5'
+        outName = 'rm3.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestMultipleConditionRuns
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,60,[],[],[],[]);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,157,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestMethodTeardown)
+        function returnHome(testCase)
+            cd(testCase.testDir)
+        end
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testRM3_MCROPT1(testCase)
+            cd RM3_MCROPT1
+            wecSim
+        end
+        
+        function testRM3_MCROPT2(testCase)
+            cd RM3_MCROPT2
+            wecSim
+        end
+        
+        function testRM3_MCROPT3(testCase)
+            cd RM3_MCROPT3
+            wecSim
+        end
+        
+        function testRM3_MCROPT3_SeaState(testCase)
+            cd RM3_MCROPT3_SeaState
+            wecSim
+        end
+        
+    end
+    
+end

--- a/Nonhydro_Body/TestNonHydroBody.m
+++ b/Nonhydro_Body/TestNonHydroBody.m
@@ -1,0 +1,70 @@
+classdef TestNonHydroBody < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'oswec.h5'
+        outName = 'oswec.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestNonHydroBody
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,30,[],[],[],[]);
+            hydro = Excitation_IRF(hydro,30,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testNonhydro_Body(testCase)
+            wecSim
+        end
+        
+    end
+    
+end

--- a/Nonhydro_Body/wecSimInputFile.m
+++ b/Nonhydro_Body/wecSimInputFile.m
@@ -2,7 +2,7 @@
 simu = simulationClass();               
 simu.simMechanicsFile = 'OSWEC.slx';  	
 simu.mode = 'normal';                   
-simu.explorer='on';                     
+simu.explorer='off';                     
 simu.startTime = 0;                    
 simu.rampTime = 100;                       
 simu.endTime=400;                       

--- a/Nonlinear_Hydro/TestNonlinearHydro.m
+++ b/Nonlinear_Hydro/TestNonlinearHydro.m
@@ -1,0 +1,93 @@
+classdef TestNonlinearHydro < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'ellipsoid.h5'
+        outName = 'ellipsoid.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestNonlinearHydro
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,60,[],[],[],[]);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,157,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestMethodTeardown)
+        function returnHome(testCase)
+            cd(testCase.testDir)
+        end
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testNonlinear_Hydro_ode4_Regular(testCase)
+            cd(fullfile('ode4', 'Regular'))
+            wecSim
+        end
+        
+        function testNonlinear_Hydro_ode4_RegularCIC(testCase)
+            cd(fullfile('ode4', 'RegularCIC'))
+            wecSim
+        end
+        
+        function testNonlinear_Hydro_ode45_Regular(testCase)
+            cd(fullfile('ode45', 'Regular'))
+            wecSim
+        end
+        
+        function testNonlinear_Hydro_ode45_RegularCIC(testCase)
+            cd(fullfile('ode45', 'RegularCIC'))
+            wecSim
+        end
+        
+    end
+    
+end

--- a/PTO-Sim/OSWEC/OSWEC_Hydraulic_Crank_PTO/wecSimInputFile.m
+++ b/PTO-Sim/OSWEC/OSWEC_Hydraulic_Crank_PTO/wecSimInputFile.m
@@ -5,7 +5,8 @@ simu.startTime = 0;
 simu.rampTime = 100;                       
 simu.endTime=400;                       
 simu.dt = 0.01;                         
-simu.CITime = 30;                       
+simu.CITime = 30;
+simu.explorer = 'off';                     % Turn SimMechanics Explorer (on/off)
 
 %% Wave Information
 %Irregular Waves using PM Spectrum

--- a/PTO-Sim/OSWEC/OSWEC_Hydraulic_PTO/wecSimInputFile.m
+++ b/PTO-Sim/OSWEC/OSWEC_Hydraulic_PTO/wecSimInputFile.m
@@ -5,7 +5,8 @@ simu.startTime = 0;
 simu.rampTime = 100;                       
 simu.endTime=400;                       
 simu.dt = 0.01;                         
-simu.CITime = 30;                       
+simu.CITime = 30;
+simu.explorer = 'off';                     % Turn SimMechanics Explorer (on/off)
 
 %% Wave Information
 %Irregular Waves using PM Spectrum

--- a/PTO-Sim/OSWEC/TestPTOSimOSWEC.m
+++ b/PTO-Sim/OSWEC/TestPTOSimOSWEC.m
@@ -1,0 +1,83 @@
+classdef TestPTOSimOSWEC < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'oswec.h5'
+        outName = 'oswec.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestPTOSimOSWEC
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,30,[],[],[],[]);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,30,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestMethodTeardown)
+        function returnHome(testCase)
+            cd(testCase.testDir)
+        end
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testOSWEC_Hydraulic_Crank_PTO(testCase)
+            cd('OSWEC_Hydraulic_Crank_PTO')
+            wecSim
+        end
+        
+        function testOSWEC_Hydraulic_PTO(testCase)
+            cd('OSWEC_Hydraulic_PTO')
+            wecSim
+        end
+        
+    end
+    
+end

--- a/PTO-Sim/RM3/RM3_DD_PTO/wecSimInputFile.m
+++ b/PTO-Sim/RM3/RM3_DD_PTO/wecSimInputFile.m
@@ -5,6 +5,7 @@ simu.startTime = 0;
 simu.rampTime = 100;                       
 simu.endTime=400;   
 simu.dt = 0.001;                       
+simu.explorer = 'off';                     % Turn SimMechanics Explorer (on/off)
 
 %% Wave Information
 % Regular Waves  

--- a/PTO-Sim/RM3/RM3_Hydraulic_PTO/wecSimInputFile.m
+++ b/PTO-Sim/RM3/RM3_Hydraulic_PTO/wecSimInputFile.m
@@ -5,6 +5,7 @@ simu.startTime = 0;
 simu.rampTime = 100;                       
 simu.endTime=400;   
 simu.dt = 0.01;                         
+simu.explorer = 'off';                     % Turn SimMechanics Explorer (on/off)
 
 %% Wave Information
 % Irregular Waves using PM Spectrum

--- a/PTO-Sim/RM3/RM3_cHydraulic_PTO/wecSimInputFile.m
+++ b/PTO-Sim/RM3/RM3_cHydraulic_PTO/wecSimInputFile.m
@@ -5,6 +5,7 @@ simu.startTime = 0;
 simu.rampTime = 100;                       
 simu.endTime=400;   
 simu.dt = 0.01;                         
+simu.explorer = 'off';                     % Turn SimMechanics Explorer (on/off)
 
 %% Wave Information
 %Irregular Waves using PM Spectrum

--- a/PTO-Sim/RM3/TestPTOSimRM3.m
+++ b/PTO-Sim/RM3/TestPTOSimRM3.m
@@ -1,0 +1,88 @@
+classdef TestPTOSimRM3 < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'rm3.h5'
+        outName = 'rm3.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestPTOSimRM3
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,60,[],[],[],[]);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,157,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestMethodTeardown)
+        function returnHome(testCase)
+            cd(testCase.testDir)
+        end
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testRM3_cHydraulic_PTO(testCase)
+            cd('RM3_cHydraulic_PTO')
+            wecSim
+        end
+        
+        function testRM3_DD_PTO(testCase)
+            cd('RM3_DD_PTO')
+            wecSim
+        end
+        
+        function testRM3_Hydraulic_PTO(testCase)
+            cd('RM3_Hydraulic_PTO')
+            wecSim
+        end
+        
+    end
+    
+end

--- a/Paraview_Visualization/OSWEC_NonLinear_Viz/TestOSWECNonLinearViz.m
+++ b/Paraview_Visualization/OSWEC_NonLinear_Viz/TestOSWECNonLinearViz.m
@@ -1,0 +1,75 @@
+classdef TestOSWECNonLinearViz < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'oswec.h5'
+        outName = 'oswec.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestOSWECNonLinearViz
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,30,[],[],[],[]);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,30,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+        function removeVTK(testCase)
+            rmdir(fullfile(testCase.testDir, 'vtk'), 's');
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testParaview_Visualization_OSWEC_NonLinear_Viz(testCase)
+            wecSim
+        end
+        
+    end
+    
+end

--- a/Paraview_Visualization/RM3_MoorDyn_Viz/TestMoorDynViz.m
+++ b/Paraview_Visualization/RM3_MoorDyn_Viz/TestMoorDynViz.m
@@ -1,0 +1,75 @@
+classdef TestMoorDynViz < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'rm3.h5'
+        outName = 'rm3.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestMoorDynViz
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,60,[],[],[],[]);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,157,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+        function removeVTK(testCase)
+            rmdir(fullfile(testCase.testDir, 'vtk'), 's');
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testParaview_Visualization_RM3_MoorDyn_Viz(testCase)
+            wecSim
+        end
+        
+    end
+    
+end

--- a/Passive_Yaw/TestPassiveYaw.m
+++ b/Passive_Yaw/TestPassiveYaw.m
@@ -1,0 +1,82 @@
+classdef TestPassiveYaw < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'oswec.h5'
+        outName = 'oswec.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestPassiveYaw
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,40,[],[],[],[]);
+            hydro = Excitation_IRF(hydro,40,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestMethodTeardown)
+        function returnHome(testCase)
+            cd(testCase.testDir)
+        end
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testPassiveYawOFF(testCase)
+            cd('PassiveYawOFF')
+            wecSim
+        end
+        
+        function testPassiveYawON(testCase)
+            cd('PassiveYawON')
+            wecSim
+        end
+        
+    end
+    
+end

--- a/WECCCOMP_Fault_Implementation/TestWECCOMP.m
+++ b/WECCCOMP_Fault_Implementation/TestWECCOMP.m
@@ -1,0 +1,71 @@
+classdef TestWECCOMP < matlab.unittest.TestCase
+    
+    properties
+        OriginalDefault
+        testDir
+        h5Dir = fullfile("hydroData")
+        h5Name = 'wavestar.h5'
+        outName = 'wavestar.out'
+    end
+    
+    
+    methods (Access = 'public')
+        
+        function obj = TestWECCOMP
+            obj.testDir = fileparts(mfilename('fullpath'));
+        end
+    
+    end
+    
+    methods (TestMethodSetup)
+        function killPlots (~)
+            set(0,'DefaultFigureVisible','off');
+        end
+    end
+    
+    methods(TestClassSetup)
+        
+        function captureVisibility(testCase)
+            testCase.OriginalDefault = get(0,'DefaultFigureVisible');
+        end
+        
+        function runBemio(testCase)
+            
+            cd(testCase.h5Dir);
+            hydro = struct();
+            hydro = Read_WAMIT(hydro,testCase.outName,[]);
+            
+            hydro = Radiation_IRF(hydro,2,[],[],[],[]);
+            hydro = Radiation_IRF_SS(hydro,[],[]);
+            hydro = Excitation_IRF(hydro,2,[],[],[],[]);
+            
+            Write_H5(hydro)
+            cd(testCase.testDir)
+            
+        end
+        
+    end
+    
+    methods(TestClassTeardown)
+        
+        function checkVisibilityRestored(testCase)
+            set(0,'DefaultFigureVisible',testCase.OriginalDefault);
+            testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
+                                 testCase.OriginalDefault);
+        end
+        
+        function removeH5(testCase)
+            delete(fullfile(testCase.h5Dir, testCase.h5Name));
+        end
+        
+    end
+    
+    methods(Test)
+        
+        function testWECCCOMP_Fault_Implementation(testCase)
+            wecSim
+        end
+        
+    end
+    
+end

--- a/runTests.m
+++ b/runTests.m
@@ -1,0 +1,19 @@
+function results = runTests(testsPath)
+
+    arguments
+        testsPath string = "."
+    end
+    
+    import matlab.unittest.TestSuite;
+    import matlab.unittest.TestRunner;
+    
+    suite = TestSuite.fromFolder(testsPath, ...
+                                 'IncludingSubfolders', true);
+    
+    % Build the runner
+    runner = TestRunner.withTextOutput;
+
+    % Run the tests
+    results = runner.run(suite);
+    
+end

--- a/write_hdf5/testWriteHDF5.m
+++ b/write_hdf5/testWriteHDF5.m
@@ -1,0 +1,7 @@
+function tests = testWriteHDF5
+    tests = functiontests(localfunctions);
+end
+
+function testcreate_hdfile(testCase)
+    run('create_h5File.m')
+end


### PR DESCRIPTION
This PR is an accompaniment to https://github.com/WEC-Sim/WEC-Sim/issues/619 and https://github.com/WEC-Sim/WEC-Sim/pull/620

Tests have been added to each level where a bemio call is made and a script to call them globally has also been added at the top level called `runTests`.

I did also reduce the number of times that the mechanics explorer is opened, by default. Some way to programmatically stop this in tests would be useful.

Some instructions regarding running the tests (i.e. needed WEC-Sim and MoorDyn) need to be added.

@akeeste, can you have a look at this and see how it compliments what you are doing?

Cheers,

Mat

TODO:

- [ ] Add instructions for tests
- [ ] ?