### PR TITLE
GBM Fix

### DIFF
--- a/Generalized_Body_Modes/userDefinedFunctions.m
+++ b/Generalized_Body_Modes/userDefinedFunctions.m
@@ -1,24 +1,18 @@
-imcr=1;
-mcr.maxPitch(imcr) = sin(max(output.bodies.position(round(end/2):end,5)))*40;
-mcr.maxHeave(imcr) = max(output.bodies.position(:,3));
-mcr.maxSurge(imcr) = max(output.bodies.position(:,1));
-mcr.waveT(imcr) = waves.T;
+% Example of user input MATLAB file for post processing
 
-%Example of user input MATLAB file for post processing
-
-%Plot waves
+% Plot waves
 waves.plotEta(simu.rampTime);
 try 
     waves.plotSpectrum();
 catch
 end
 
-%Plot surge response for body 1
+% Plot surge response for body 1
 output.plotResponse(1,1);
 
-%Plot heave response for body 1
+% Plot heave response for body 1
 output.plotResponse(1,3);
 
 
-%Plot heave forces for body 1
+% Plot heave forces for body 1
 output.plotForces(1,3);


### PR DESCRIPTION
This PR removes some unnecessary post-processing from the GBM application that prevents it from running multiple times in a row. It defines ``mcr`` and ``imcr`` variables that break the ``wecSim`` command. These variables are not relevant to the post-processing.