### PR TITLE
Remove fixed mass option

### DIFF
--- a/Desalination/wecSimInputFile.m
+++ b/Desalination/wecSimInputFile.m
@@ -38,7 +38,8 @@ body(1).morisonElement.rgME = [0 0 -3; 0 0 -1.2; 0 0 0.6; 0 0 2.4; 0 0 4.2];
 %% Base
 body(2) = bodyClass('./hydroData/oswec.h5');   % Initialize bodyClass for Base
 body(2).geometryFile = './geometry/base.stl';  % Geometry File
-body(2).mass = 'fixed';                        % Creates Fixed Body
+body(2).mass = 999;                            % Placeholder mass for fixed body
+body(2).inertia = [999 999 999];               % Placeholder inertia for fixed body
 
 %% PTO and Constraint Parameters
 constraint(1)= constraintClass('Constraint1'); % Initialize ConstraintClass 

--- a/PTO-Sim/OSWEC/OSWEC_Hydraulic_Crank_PTO/wecSimInputFile.m
+++ b/PTO-Sim/OSWEC/OSWEC_Hydraulic_Crank_PTO/wecSimInputFile.m
@@ -25,9 +25,10 @@ body(1).inertia = [1.85e6 1.85e6 1.85e6];
 body(1).linearDamping(5,5) = 1*10^7;    % Specify damping on body 1 in pich
 
 % Base
-body(2) = bodyClass('../hydroData/oswec.h5');   
-body(2).geometryFile = '../geometry/base.stl';    
-body(2).mass = 'fixed';                        
+body(2) = bodyClass('../hydroData/oswec.h5');
+body(2).geometryFile = '../geometry/base.stl';
+body(2).mass = 999;                             % Placeholder mass for fixed body
+body(2).inertia = [999 999 999];                % Placeholder inertia for fixed body
 
 %% PTO and Constraint Parameters
 % Fixed Constraint

--- a/PTO-Sim/OSWEC/OSWEC_Hydraulic_PTO/wecSimInputFile.m
+++ b/PTO-Sim/OSWEC/OSWEC_Hydraulic_PTO/wecSimInputFile.m
@@ -25,9 +25,10 @@ body(1).inertia = [1.85e6 1.85e6 1.85e6];
 body(1).linearDamping(5,5) = 1*10^7;    % Specify damping on body 1 in pich
 
 % Base
-body(2) = bodyClass('../hydroData/oswec.h5');   
-body(2).geometryFile = '../geometry/base.stl';    
-body(2).mass = 'fixed';                        
+body(2) = bodyClass('../hydroData/oswec.h5');
+body(2).geometryFile = '../geometry/base.stl';
+body(2).mass = 999;                             % Placeholder mass for fixed body
+body(2).inertia = [999 999 999];                % Placeholder inertia for fixed body
 
 %% PTO and Constraint Parameters
 % Fixed Constraint

--- a/Passive_Yaw/PassiveYawOFF/wecSimInputFile.m
+++ b/Passive_Yaw/PassiveYawOFF/wecSimInputFile.m
@@ -29,7 +29,8 @@ body(1).yaw.option=0;                           % Turn passive yaw OFF
 % Base NOTE: This test uses unique BEM for the OSWEC
 body(2) = bodyClass('../hydroData/oswec.h5');   % Initialize bodyClass for Base
 body(2).geometryFile = '../geometry/base.stl';  % Geometry File
-body(2).mass = 'fixed';                         % Creates Fixed Body
+body(2).mass = 999;                             % Placeholder mass for fixed body
+body(2).inertia = [999 999 999];                % Placeholder inertia for fixed body
 body(2).yaw.option=0;                           % Turn passive yaw OFF
 
 %% PTO and Constraint Parameters

--- a/Passive_Yaw/PassiveYawON/wecSimInputFile.m
+++ b/Passive_Yaw/PassiveYawON/wecSimInputFile.m
@@ -30,7 +30,8 @@ body(1).yaw.threshold=0.01;                     % Set passive yaw threshold
 % Base NOTE: This test uses unique BEM for the OSWEC
 body(2) = bodyClass('../hydroData/oswec.h5');   % Initialize bodyClass for Base
 body(2).geometryFile = '../geometry/base.stl';  % Geometry File
-body(2).mass = 'fixed';                         % Creates Fixed Body
+body(2).mass = 999;                             % Placeholder mass for fixed body
+body(2).inertia = [999 999 999];                % Placeholder inertia for fixed body
 body(2).yaw.option=1;                           % Turn passive yaw ON
 body(2).yaw.threshold=0.01;                     % Set passive yaw threshold
 

--- a/Passive_Yaw/PassiveYawRegression/wecSimInputFile.m
+++ b/Passive_Yaw/PassiveYawRegression/wecSimInputFile.m
@@ -32,7 +32,8 @@ body(1).yaw.threshold=1;                        % Set passive yaw threshold
 % Base NOTE: This test uses unique BEM for the OSWEC
 body(2) = bodyClass('../hydroData/oswec.h5');   % Initialize bodyClass for Base
 body(2).geometryFile = '../geometry/base.stl';  % Geometry File
-body(2).mass = 'fixed';                         % Creates Fixed Body
+body(2).mass = 999;                             % Placeholder mass for fixed body
+body(2).inertia = [999 999 999];                % Placeholder inertia for fixed body
 body(2).yaw.option=1;                           % Turn passive yaw ON
 body(2).yaw.threshold=1;                        % Set passive yaw threshold
 

--- a/Wave_Markers/OSWEC/wecSimInputFile.m
+++ b/Wave_Markers/OSWEC/wecSimInputFile.m
@@ -51,7 +51,8 @@ body(1).inertia = [1.85e6 1.85e6 1.85e6];  % Moment of Inertia [kg-m^2]
 % Base
 body(2) = bodyClass('hydroData/oswec.h5');      % Initialize bodyClass for Base
 body(2).geometryFile = 'geometry/base.stl';     % Geometry File
-body(2).mass = 'fixed';                         % Creates Fixed Body
+body(2).mass = 999;                             % Placeholder mass for fixed body
+body(2).inertia = [999 999 999];                % Placeholder inertia for fixed body
 
 %% PTO and Constraint Parameters
 % Fixed


### PR DESCRIPTION
This PR accompanies WEC-Sim/WEC-Sim#856 by removing the fixed mass options in all applications' ``wecSimInputFile``

For after v5.0