### PR TITLE
Reimplement Desalination Test and Fix R2020b tests

### DIFF
--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -42,8 +42,10 @@ jobs:
                  WECCCOMP,
                  Write_Custom_h5]
         include:
+          - products: Simulink Simscape Simscape_Multibody
           - release: latest
             folder: Desalination
+            products: Simulink Simscape Simscape_Multibody Simscape_Fluids
     name: ${{ matrix.folder }} on MATLAB ${{ matrix.release }}
     steps:
       - name: Check out repository (repository dispatch)
@@ -80,6 +82,8 @@ jobs:
         uses: matlab-actions/setup-matlab@v2-beta
         with:
           cache: true
+          products: ${{ matrix.products }}
+          release: ${{ matrix.release }}
       - name: Start display server
         if: matrix.folder == 'Desalination'
         run: |

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -41,6 +41,9 @@ jobs:
                  Wave_Markers,
                  WECCCOMP,
                  Write_Custom_h5]
+        include:
+          - release: latest
+            folder: Desalination
     name: ${{ matrix.folder }} on MATLAB ${{ matrix.release }}
     steps:
       - name: Check out repository (repository dispatch)
@@ -74,7 +77,15 @@ jobs:
         shell: bash
         working-directory: './MoorDyn'
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2-beta
+        with:
+          cache: true
+      - name: Start display server
+        if: matrix.folder == 'Desalination'
+        run: |
+          sudo apt-get install xvfb
+          Xvfb :99 &
+          echo "DISPLAY=:99" >> $GITHUB_ENV
       - name: Install WEC-Sim
         uses: matlab-actions/run-command@v1
         with:
@@ -83,3 +94,4 @@ jobs:
         uses: matlab-actions/run-command@v1
         with:
           command: results = wecSimAppTest("${{ matrix.folder }}"), assertSuccess(results);
+

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -46,6 +46,8 @@ jobs:
           - release: latest
             folder: Desalination
             products: Simulink Simscape Simscape_Multibody Simscape_Fluids
+          - folder: Controls
+            products: Simulink Simscape Simscape_Multibody Control_System_Toolbox
     name: ${{ matrix.folder }} on MATLAB ${{ matrix.release }}
     steps:
       - name: Check out repository (repository dispatch)


### PR DESCRIPTION
This PR reinstates the desalination test by using the display server approach suggested [here](https://github.com/matlab-actions/run-command/issues/35#issuecomment-1736614996).

The `setup-matlab` action is also updated to [`v2-beta`](https://github.com/matlab-actions/setup-matlab/tree/v2-beta#set-up-matlab) which would allow testing on Windows, although the additional time requirements for the extra tests would need to be considered.

Also, it seems that the specified MATLAB versions (R2020b, latest) were never being installed, just the latest version each time. Now that R2020b is being testing, the one of the controls tests is failing, possibly because of the Simulink file version.
