### PR TITLE
Test Windows on R2023b

### DIFF
--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         folder: [Body-to-Body_Interactions,
                  Cable,
                  Controls,
@@ -46,7 +47,6 @@ jobs:
                  WECCCOMP,
                  Write_Custom_h5]
         release: [R2023b]
-        os: [ubuntu-latest, windows-latest]
         include:
           - products: Simulink Simscape Simscape_Multibody
           - folder: Desalination

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -95,7 +95,6 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2-beta
         with:
-          cache: true
           products: ${{ matrix.products }}
           release: ${{ matrix.release }}
       - name: Start display server (Linux)

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -62,26 +62,26 @@ jobs:
     name: "${{ matrix.folder }} - ${{ matrix.os }} - ${{ matrix.release }}"
     steps:
       - name: Check out repository (repository dispatch)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
           ref: 'dev'
         if: github.event_name == 'repository_dispatch'
       - name: Check out repository (push or pull request)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
         if: github.event_name != 'repository_dispatch'
       - name: Checkout LFS objects
         run: git lfs checkout
       - name: Check out WEC-Sim
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: WEC-Sim/WEC-Sim
           ref: 'dev'
           path: './WEC-Sim'
       - name: Check out MoorDyn
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: WEC-Sim/MoorDyn
           path: './MoorDyn'

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -104,11 +104,11 @@ jobs:
           sudo apt-get install xvfb
           Xvfb :99 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
-      - name: Install WEC-Sim
-        uses: matlab-actions/run-command@v1
-        with:
-          command: addpath(genpath('WEC-Sim/source'));, savepath pathdef.m;
+#      - name: Install WEC-Sim
+#        uses: matlab-actions/run-command@v1
+#        with:
+#          command: addpath(genpath('WEC-Sim/source'));, savepath pathdef.m;
       - name: Run tests and generate artifacts
         uses: matlab-actions/run-command@v1
         with:
-          command: results = wecSimAppTest("${{ matrix.folder }}"), assertSuccess(results);
+          command: addpath(genpath('WEC-Sim/source')); results = wecSimAppTest("${{ matrix.folder }}"), assertSuccess(results);

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -104,11 +104,10 @@ jobs:
           sudo apt-get install xvfb
           Xvfb :99 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
-#      - name: Install WEC-Sim
-#        uses: matlab-actions/run-command@v1
-#        with:
-#          command: addpath(genpath('WEC-Sim/source'));, savepath pathdef.m;
-      - name: Run tests and generate artifacts
+      - name: Install WEC-Sim, run tests and generate artifacts
         uses: matlab-actions/run-command@v1
         with:
-          command: addpath(genpath('WEC-Sim/source')); results = wecSimAppTest("${{ matrix.folder }}"), assertSuccess(results);
+          command: |
+            addpath(genpath('WEC-Sim/source'));
+            results = wecSimAppTest("${{ matrix.folder }}"),
+            assertSuccess(results);

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -23,8 +23,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        release: [R2023b]
         folder: [Body-to-Body_Interactions,
                  Cable,
                  Controls,
@@ -47,6 +45,8 @@ jobs:
                  Wave_Markers,
                  WECCCOMP,
                  Write_Custom_h5]
+        release: [R2023b]
+        os: [ubuntu-latest, windows-latest]
         include:
           - products: Simulink Simscape Simscape_Multibody
           - folder: Desalination

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -19,11 +19,12 @@ jobs:
     steps:
         - run: echo "Triggered by WEC-Sim commit ${{ github.event.client_payload.sha }}"
   run_tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        release: [latest]
+        os: [ubuntu-latest, windows-latest]
+        release: [R2023b]
         folder: [Body-to-Body_Interactions,
                  Cable,
                  Controls,
@@ -58,7 +59,7 @@ jobs:
             products: Simulink Simscape Simscape_Multibody Control_System_Toolbox
           - folder: WECCCOMP
             products: Simulink Simscape Simscape_Multibody Control_System_Toolbox Optimization_Toolbox System_Identification_Toolbox Statistics_and_Machine_Learning_Toolbox
-    name: ${{ matrix.folder }} MATLAB ${{ matrix.release }} on Linux
+    name: ${{ matrix.folder }} MATLAB ${{ matrix.release }} on ${{ matrix.os }}
     steps:
       - name: Check out repository (repository dispatch)
         uses: actions/checkout@v2

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -59,7 +59,7 @@ jobs:
             products: Simulink Simscape Simscape_Multibody Control_System_Toolbox
           - folder: WECCCOMP
             products: Simulink Simscape Simscape_Multibody Control_System_Toolbox Optimization_Toolbox System_Identification_Toolbox Statistics_and_Machine_Learning_Toolbox
-    name: ${{ matrix.folder }} MATLAB ${{ matrix.release }} on ${{ matrix.os }}
+    name: "${{ matrix.folder }} - ${{ matrix.os }} - ${{ matrix.release }}"
     steps:
       - name: Check out repository (repository dispatch)
         uses: actions/checkout@v2

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -97,8 +97,8 @@ jobs:
           cache: true
           products: ${{ matrix.products }}
           release: ${{ matrix.release }}
-      - name: Start display server
-        if: matrix.folder == 'Desalination'
+      - name: Start display server (Linux)
+        if: matrix.folder == 'Desalination' && matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get install xvfb
           Xvfb :99 &

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -110,3 +110,7 @@ jobs:
             addpath(genpath('WEC-Sim/source'));
             results = wecSimAppTest("${{ matrix.folder }}"),
             assertSuccess(results);
+          startup-options: -logfile matlab.log
+      - name: Print matlab.log
+        if: success() || failure()
+        run: cat matlab.log

--- a/.github/workflows/run-tests-dev.yml
+++ b/.github/workflows/run-tests-dev.yml
@@ -60,6 +60,7 @@ jobs:
           - folder: WECCCOMP
             products: Simulink Simscape Simscape_Multibody Control_System_Toolbox Optimization_Toolbox System_Identification_Toolbox Statistics_and_Machine_Learning_Toolbox
     name: "${{ matrix.folder }} - ${{ matrix.os }} - ${{ matrix.release }}"
+    timeout-minutes: 45
     steps:
       - name: Check out repository (repository dispatch)
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests-master.yml
+++ b/.github/workflows/run-tests-master.yml
@@ -103,3 +103,7 @@ jobs:
             addpath(genpath('WEC-Sim/source'));
             results = wecSimAppTest("${{ matrix.folder }}"),
             assertSuccess(results);
+          startup-options: -logfile matlab.log
+      - name: Print matlab.log
+        if: success() || failure()
+        run: cat matlab.log

--- a/.github/workflows/run-tests-master.yml
+++ b/.github/workflows/run-tests-master.yml
@@ -88,7 +88,6 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2-beta
         with:
-          cache: true
           products: ${{ matrix.products }}
           release: ${{ matrix.release }}
       - name: Start display server (Linux)

--- a/.github/workflows/run-tests-master.yml
+++ b/.github/workflows/run-tests-master.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
         - run: echo "Triggered by WEC-Sim commit ${{ github.event.client_payload.sha }}"
   run_tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        release: [latest]
+        os: [ubuntu-latest, windows-latest]
         folder: [Body-to-Body_Interactions,
                  Cable,
                  Controls,
@@ -44,6 +44,7 @@ jobs:
                  Wave_Markers,
                  WECCCOMP,
                  Write_Custom_h5]
+        release: [R2023b]
         include:
           - products: Simulink Simscape Simscape_Multibody
           - folder: Desalination
@@ -52,29 +53,29 @@ jobs:
             products: Simulink Simscape Simscape_Multibody Control_System_Toolbox Optimization_Toolbox System_Identification_Toolbox Statistics_and_Machine_Learning_Toolbox Symbolic_Math_Toolbox
           - folder: WECCCOMP
             products: Simulink Simscape Simscape_Multibody Control_System_Toolbox Optimization_Toolbox System_Identification_Toolbox Statistics_and_Machine_Learning_Toolbox 
-    name: ${{ matrix.folder }} MATLAB ${{ matrix.release }} on Linux
+    name: "${{ matrix.folder }} - ${{ matrix.os }} - ${{ matrix.release }}"
     steps:
       - name: Check out repository (repository dispatch)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
           ref: 'master'
         if: github.event_name == 'repository_dispatch'
       - name: Check out repository (push or pull request)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
         if: github.event_name != 'repository_dispatch'
       - name: Checkout LFS objects
         run: git lfs checkout
       - name: Check out WEC-Sim
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: WEC-Sim/WEC-Sim
           ref: 'master'
           path: './WEC-Sim'
       - name: Check out MoorDyn
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: WEC-Sim/MoorDyn
           path: './MoorDyn'
@@ -90,17 +91,16 @@ jobs:
           cache: true
           products: ${{ matrix.products }}
           release: ${{ matrix.release }}
-      - name: Start display server
-        if: matrix.folder == 'Desalination'
+      - name: Start display server (Linux)
+        if: matrix.folder == 'Desalination' && matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get install xvfb
           Xvfb :99 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
-      - name: Install WEC-Sim
+      - name: Install WEC-Sim, run tests and generate artifacts
         uses: matlab-actions/run-command@v1
         with:
-          command: addpath(genpath('WEC-Sim/source'));, savepath pathdef.m;
-      - name: Run tests and generate artifacts
-        uses: matlab-actions/run-command@v1
-        with:
-          command: results = wecSimAppTest("${{ matrix.folder }}"), assertSuccess(results);
+          command: >
+            addpath(genpath('WEC-Sim/source'));
+            results = wecSimAppTest("${{ matrix.folder }}"),
+            assertSuccess(results);


### PR DESCRIPTION
This PR adds tests for Windows on R2023b.

Note that I needed to remove the separate "Install WEC-Sim" step as the `savepath pathdef.m` command seemed to be causing lock ups.
