### PR TITLE
Disable MoorDyn print timestep to command window

### DIFF
--- a/Mooring/MoorDyn/Mooring/lines.txt
+++ b/Mooring/MoorDyn/Mooring/lines.txt
@@ -39,6 +39,7 @@ ID     LineType  AttachA  AttachB  UnstrLen     NumSegs   LineOutputs
 200.0    TmaxIC       - max time for ic gen (s)
 2        writeLog     - Write a log file
 0        WriteUnits   - 0: do not write the units header on the output files
+1        disableOutTime - 1: do not write timesteps to command window
 -------------------------- OUTPUTS --------------------------------
 FairTen4
 FairTen5

--- a/Paraview_Visualization/RM3_MoorDyn_Viz/Mooring/lines.txt
+++ b/Paraview_Visualization/RM3_MoorDyn_Viz/Mooring/lines.txt
@@ -33,6 +33,7 @@ ID     LineType  AttachA  AttachB  UnstrLen     NumSegs   LineOutputs
 200.0    TmaxIC       - max time for ic gen (s)
 2        writeLog     - Write a log file
 0        WriteUnits   - 0: do not write the units header on the output files
+1        disableOutTime - 1: do not write timesteps to command window
 -------------------------- OUTPUTS --------------------------------
 FairTen1
 FairTen2


### PR DESCRIPTION
This PR disables MoorDyn's printing of the timestep to the command window for the applications using MoorDyn. Previously, the printing to the command window was annoying and unnecessary:

![image](https://github.com/user-attachments/assets/3ef94cfa-6349-4e0f-8c23-f4b56dbdfd3e)

The ability to disable this feature was added in a [commit](https://github.com/FloatingArrayDesign/MoorDyn/commit/327c2be319b73d0adf41e9c5d8f2887328ff99f0) included in MoorDyn v2.4.0.

Note that this PR does not disable the timestep for versions before v2.4.0. For those cases, the command just doesn't change anything. To see the timestep disabled, the new libmoordyn.dll from [PR to WEC-Sim/MoorDyn](https://github.com/WEC-Sim/MoorDyn/pull/15) will need to be used.