### PR TITLE
Allow tests to run on dev

### DIFF
--- a/.github/workflows/run-tests-reusable.yml
+++ b/.github/workflows/run-tests-reusable.yml
@@ -34,7 +34,8 @@ jobs:
             folder: Mooring
           - os: ubuntu-latest
             folder: OWC
-          - folder: Paraview_Visualization
+          - os: ubuntu-latest
+            folder: Paraview_Visualization
     name: "${{ matrix.folder }} - ${{ matrix.os }} - ${{ matrix.release }}"
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
This PR updates the `run-tests-reusable.yml` to specify the os and folder when excluding folders. This should fix the workflow so the tests will be running again on the dev branch when a repository dispatch event occurs (e.g. merge).