### PR TITLE
Allow tests to run on main

### DIFF
--- a/.github/workflows/run-tests-reusable.yml
+++ b/.github/workflows/run-tests-reusable.yml
@@ -30,8 +30,10 @@ jobs:
         release: [R2024b]
         include: ${{ fromJSON(inputs.include) }}
         exclude:
-          - folder: Mooring
-          - folder: Paraview_Visualization
+          - os: ubuntu-latest
+            folder: Mooring
+          - os: ubuntu-latest
+            folder: Paraview_Visualization
     name: "${{ matrix.folder }} - ${{ matrix.os }} - ${{ matrix.release }}"
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
This PR updates the `run-tests-reusable.yml` to specify the os and folder when excluding folders. This should fix the workflow so the tests will be running again on the main branch when a repository dispatch event occurs (e.g. merge).