### PR TITLE
Control optimal gains interpolation

### DIFF
--- a/Controls/Declutching/optimalTimeCalc.m
+++ b/Controls/Declutching/optimalTimeCalc.m
@@ -61,7 +61,7 @@ ylabel('mag (dB)')
 grid on
 xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','resonant Frequency','Wave Frequency','Location','southwest')
+legend('','Resonant Frequency','Wave Frequency','Location','southwest')
 
 subplot(2,1,2)
 semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Phase)
@@ -70,7 +70,7 @@ ylabel('phase (deg)')
 grid on
 xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','resonant Frequency','Wave Frequency','Location','northwest')
+legend('','Resonant Frequency','Wave Frequency','Location','northwest')
 
 % Determine optimal latching time
 optDeclutchTime = 0.5*(resonantPeriod - T)

--- a/Controls/Declutching/optimalTimeCalc.m
+++ b/Controls/Declutching/optimalTimeCalc.m
@@ -1,15 +1,14 @@
 % This script identifies the dynamics of the float in the respective wave 
 % conditions and determines the optimal proportional gain value for a 
 % passive controller (for regular waves)
-
 close all; clear all; clc;
 
+dof = 3;            % Caluclate for heave motion
 % Inputs (from wecSimInputFile)
 simu = simulationClass();
 body(1) = bodyClass('../../_Common_Input_Files/Sphere/hydroData/sphere.h5');
 waves.height = 2.5;                          % Wave Height [m]
 waves.period = 9.6664;                       % Wave Period [s]
-dof = 3;        % changing this value reguires changing the device mass
 
 % Load hydrodynamic data for float from BEM
 hydro = readBEMIOH5(body.h5File{1}, 1, body.meanDrift);
@@ -49,10 +48,9 @@ Zi = Gi./(1j*hydro.simulation_parameters.w_extended');
 Mag = 20*log10(abs(Zi));
 Phase = (angle(Zi))*(180/pi);
 
-% Determine natural frequency based on the phase of the impedance
-[~,closestIndNat] = min(abs(imag(Zi)));
-natFreq = hydro.simulation_parameters.w_extended(closestIndNat);
-natT = (2*pi)/natFreq;
+% Determine resonant frequency based on the phase of the impedance
+resonantFreq = interp1(Phase, hydro.simulation_parameters.w_extended, 0, 'spline','extrap');
+resonantPeriod = (2*pi)/resonantFreq;
 
 % Create bode plot for impedance
 figure()
@@ -61,21 +59,21 @@ semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Mag)
 xlabel('freq (hz)')
 ylabel('mag (dB)')
 grid on
-xline(natFreq/(2*pi))
+xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','southwest')
+legend('','resonant Frequency','Wave Frequency','Location','southwest')
 
 subplot(2,1,2)
 semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Phase)
 xlabel('freq (hz)')
 ylabel('phase (deg)')
 grid on
-xline(natFreq/(2*pi))
+xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','northwest')
+legend('','resonant Frequency','Wave Frequency','Location','northwest')
 
 % Determine optimal latching time
-optDeclutchTime = 0.5*(natT - T)
+optDeclutchTime = 0.5*(resonantPeriod - T)
 KpOpt = sqrt(radiationDamping(omegaIndex)^2 + ((hydrostaticStiffness/omega) - omega*(mass + addedMass(omegaIndex)))^2)
 
 % Calculate the maximum potential power

--- a/Controls/Declutching/optimalTimeCalc.m
+++ b/Controls/Declutching/optimalTimeCalc.m
@@ -6,9 +6,10 @@ close all; clear all; clc;
 
 % Inputs (from wecSimInputFile)
 simu = simulationClass();
-body(1) = bodyClass('../hydroData/sphere.h5');
-waves.height = 1;
-waves.period = 3.5;
+body(1) = bodyClass('../../_Common_Input_Files/Sphere/hydroData/sphere.h5');
+waves.height = 2.5;                          % Wave Height [m]
+waves.period = 9.6664;                       % Wave Period [s]
+dof = 3;        % changing this value reguires changing the device mass
 
 % Load hydrodynamic data for float from BEM
 hydro = readBEMIOH5(body.h5File{1}, 1, body.meanDrift);
@@ -19,20 +20,30 @@ A = H/2;
 T = waves.period;
 omega = (1/T)*(2*pi);
 
+% Extend the freq vector to include the wave frequency
+hydro.simulation_parameters.w_extended = sort([hydro.simulation_parameters.w omega]);
+omegaIndex = find(hydro.simulation_parameters.w_extended == omega, 1, 'first');
+
 % Define excitation force based on wave conditions
-ampSpect = zeros(length(hydro.simulation_parameters.w),1);
-[~,closestIndOmega] = min(abs(omega-hydro.simulation_parameters.w));
-ampSpect(closestIndOmega) = A;
-FeRao = squeeze(hydro.hydro_coeffs.excitation.re(3,:))'*simu.rho*simu.gravity + squeeze(hydro.hydro_coeffs.excitation.im(3,:))'*simu.rho*simu.gravity*1j;
-Fexc = ampSpect.*FeRao;
+ampSpect = zeros(length(hydro.simulation_parameters.w_extended),1);
+ampSpect(omegaIndex) = A;
+Fe_re = squeeze(hydro.hydro_coeffs.excitation.re(dof, 1, :)) * simu.rho * simu.gravity;
+Fe_im = squeeze(hydro.hydro_coeffs.excitation.im(dof, 1, :)) * simu.rho * simu.gravity;
+
+Fe_interp = interp1(hydro.simulation_parameters.w, Fe_re + 1j * Fe_im, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+Fexc = ampSpect.*Fe_interp;
 
 % Define the intrinsic mechanical impedance for the device
 mass = simu.rho*hydro.properties.volume;
-addedMass = squeeze(hydro.hydro_coeffs.added_mass.all(3,3,:))*simu.rho;
-radiationDamping = squeeze(hydro.hydro_coeffs.radiation_damping.all(3,3,:)).*squeeze(hydro.simulation_parameters.w')*simu.rho;
-hydrostaticStiffness = hydro.hydro_coeffs.linear_restoring_stiffness(3,3)*simu.rho*simu.gravity;
-Gi = -((hydro.simulation_parameters.w)'.^2.*(mass+addedMass)) + 1j*hydro.simulation_parameters.w'.*radiationDamping + hydrostaticStiffness;
-Zi = Gi./(1j*hydro.simulation_parameters.w');
+addedMass = squeeze(hydro.hydro_coeffs.added_mass.all(dof, dof, :)) * simu.rho;
+addedMass = interp1(hydro.simulation_parameters.w, addedMass, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+
+radiationDamping = squeeze(hydro.hydro_coeffs.radiation_damping.all(dof,dof,:)).*squeeze(hydro.simulation_parameters.w')*simu.rho;
+radiationDamping = interp1(hydro.simulation_parameters.w, radiationDamping, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+
+hydrostaticStiffness = hydro.hydro_coeffs.linear_restoring_stiffness(dof, dof) * simu.rho * simu.gravity;
+Gi = -((hydro.simulation_parameters.w_extended)'.^2 .* (mass+addedMass)) + 1j * hydro.simulation_parameters.w_extended'.*radiationDamping + hydrostaticStiffness;
+Zi = Gi./(1j*hydro.simulation_parameters.w_extended');
 
 % Calculate magnitude and phase for bode plot
 Mag = 20*log10(abs(Zi));
@@ -40,13 +51,13 @@ Phase = (angle(Zi))*(180/pi);
 
 % Determine natural frequency based on the phase of the impedance
 [~,closestIndNat] = min(abs(imag(Zi)));
-natFreq = hydro.simulation_parameters.w(closestIndNat);
+natFreq = hydro.simulation_parameters.w_extended(closestIndNat);
 natT = (2*pi)/natFreq;
 
 % Create bode plot for impedance
 figure()
 subplot(2,1,1)
-semilogx((hydro.simulation_parameters.w)/(2*pi),Mag)
+semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Mag)
 xlabel('freq (hz)')
 ylabel('mag (dB)')
 grid on
@@ -55,7 +66,7 @@ xline(1/T,'--')
 legend('','Natural Frequency','Wave Frequency','Location','southwest')
 
 subplot(2,1,2)
-semilogx((hydro.simulation_parameters.w)/(2*pi),Phase)
+semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Phase)
 xlabel('freq (hz)')
 ylabel('phase (deg)')
 grid on
@@ -65,7 +76,7 @@ legend('','Natural Frequency','Wave Frequency','Location','northwest')
 
 % Determine optimal latching time
 optDeclutchTime = 0.5*(natT - T)
-KpOpt = sqrt(radiationDamping(closestIndOmega)^2 + ((hydrostaticStiffness/omega) - omega*(mass + addedMass(closestIndOmega)))^2)
+KpOpt = sqrt(radiationDamping(omegaIndex)^2 + ((hydrostaticStiffness/omega) - omega*(mass + addedMass(omegaIndex)))^2)
 
 % Calculate the maximum potential power
 P_max = -sum(abs(Fexc).^2./(8*real(Zi)))

--- a/Controls/Latching/optimalTimeCalc.m
+++ b/Controls/Latching/optimalTimeCalc.m
@@ -1,21 +1,17 @@
 % This script identifies the dynamics of the float in the respective wave 
 % conditions and determines the optimal proportional gain and latching time
 % value for a regular wave
-
 close all; clear all; clc;
 
+dof = 3;            % Caluclate for heave motion
 % Inputs (from wecSimInputFile)
 simu = simulationClass();
 body(1) = bodyClass('../../_Common_Input_Files/Sphere/hydroData/sphere.h5');
 waves.height = 2.5;
 waves.period = 9.6664;
 
-
 % Load hydrodynamic data for float from BEM
 hydro = readBEMIOH5(body.h5File{1}, 1, body.meanDrift);
-
-dof = 3;            % Caluclate for heave motion
-mass = simu.rho*hydro.properties.volume;
 
 % Define wave conditions
 H = waves.height;
@@ -38,6 +34,7 @@ Fe_interp = interp1(hydro.simulation_parameters.w, Fe_re + 1j * Fe_im, hydro.sim
 Fexc = ampSpect.*Fe_interp;
 
 % Define the intrinsic mechanical impedance for the device
+mass = simu.rho*hydro.properties.volume;
 addedMass = squeeze(hydro.hydro_coeffs.added_mass.all(dof, dof, :)) * simu.rho;
 addedMass = interp1(hydro.simulation_parameters.w, addedMass, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
 
@@ -52,10 +49,9 @@ Zi = Gi./(1j*hydro.simulation_parameters.w_extended');
 Mag = 20*log10(abs(Zi));
 Phase = (angle(Zi))*(180/pi);
 
-% Determine natural frequency based on the phase of the impedance
-[~,closestIndNat] = min(abs(imag(Zi)));
-natFreq = hydro.simulation_parameters.w_extended(closestIndNat);
-natT = (2*pi)/natFreq;
+% Determine resonant frequency based on the phase of the impedance
+resonantFreq = interp1(Phase, hydro.simulation_parameters.w_extended, 0, 'spline','extrap');
+resonantPeriod = (2*pi)/resonantFreq;
 
 % Create bode plot for impedance
 figure()
@@ -64,21 +60,21 @@ semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Mag)
 xlabel('freq (hz)')
 ylabel('mag (dB)')
 grid on
-xline(natFreq/(2*pi))
+xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','southwest')
+legend('','resonant Frequency','Wave Frequency','Location','southwest')
 
 subplot(2,1,2)
 semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Phase)
 xlabel('freq (hz)')
 ylabel('phase (deg)')
 grid on
-xline(natFreq/(2*pi))
+xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','northwest')
+legend('','resonant Frequency','Wave Frequency','Location','northwest')
 
 % Determine optimal latching time
-optLatchTime = 0.5*(T - natT)
+optLatchTime = 0.5*(T - resonantPeriod)
 KpOpt = radiationDamping(omegaIndex)
 force = 80*(mass+addedMass(omegaIndex))
 

--- a/Controls/Latching/optimalTimeCalc.m
+++ b/Controls/Latching/optimalTimeCalc.m
@@ -6,12 +6,16 @@ close all; clear all; clc;
 
 % Inputs (from wecSimInputFile)
 simu = simulationClass();
-body(1) = bodyClass('../hydroData/sphere.h5');
+body(1) = bodyClass('../../_Common_Input_Files/Sphere/hydroData/sphere.h5');
 waves.height = 2.5;
 waves.period = 9.6664;
 
+
 % Load hydrodynamic data for float from BEM
 hydro = readBEMIOH5(body.h5File{1}, 1, body.meanDrift);
+
+dof = 3;            % Caluclate for heave motion
+mass = simu.rho*hydro.properties.volume;
 
 % Define wave conditions
 H = waves.height;
@@ -19,20 +23,30 @@ A = H/2;
 T = waves.period;
 omega = (1/T)*(2*pi);
 
+% Extend the freq vector to include the wave frequency
+hydro.simulation_parameters.w_extended = sort([hydro.simulation_parameters.w omega]);
+omegaIndex = find(hydro.simulation_parameters.w_extended == omega, 1, 'first');
+
 % Define excitation force based on wave conditions
-ampSpect = zeros(length(hydro.simulation_parameters.w),1);
-[~,closestIndOmega] = min(abs(omega-hydro.simulation_parameters.w));
-ampSpect(closestIndOmega) = A;
-FeRao = squeeze(hydro.hydro_coeffs.excitation.re(3,:))'*simu.rho*simu.gravity + squeeze(hydro.hydro_coeffs.excitation.im(3,:))'*simu.rho*simu.gravity*1j;
-Fexc = ampSpect.*FeRao;
+ampSpect = zeros(length(hydro.simulation_parameters.w_extended),1);
+[~,closestIndOmega] = min(abs(omega-hydro.simulation_parameters.w_extended));
+ampSpect(omegaIndex) = A;
+Fe_re = squeeze(hydro.hydro_coeffs.excitation.re(dof, 1, :)) * simu.rho * simu.gravity;
+Fe_im = squeeze(hydro.hydro_coeffs.excitation.im(dof, 1, :)) * simu.rho * simu.gravity;
+
+Fe_interp = interp1(hydro.simulation_parameters.w, Fe_re + 1j * Fe_im, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+Fexc = ampSpect.*Fe_interp;
 
 % Define the intrinsic mechanical impedance for the device
-mass = simu.rho*hydro.properties.volume;
-addedMass = squeeze(hydro.hydro_coeffs.added_mass.all(3,3,:))*simu.rho;
-radiationDamping = squeeze(hydro.hydro_coeffs.radiation_damping.all(3,3,:)).*squeeze(hydro.simulation_parameters.w')*simu.rho;
-hydrostaticStiffness = hydro.hydro_coeffs.linear_restoring_stiffness(3,3)*simu.rho*simu.gravity;
-Gi = -((hydro.simulation_parameters.w)'.^2.*(mass+addedMass)) + 1j*hydro.simulation_parameters.w'.*radiationDamping + hydrostaticStiffness;
-Zi = Gi./(1j*hydro.simulation_parameters.w');
+addedMass = squeeze(hydro.hydro_coeffs.added_mass.all(dof, dof, :)) * simu.rho;
+addedMass = interp1(hydro.simulation_parameters.w, addedMass, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+
+radiationDamping = squeeze(hydro.hydro_coeffs.radiation_damping.all(dof,dof,:)).*squeeze(hydro.simulation_parameters.w')*simu.rho;
+radiationDamping = interp1(hydro.simulation_parameters.w, radiationDamping, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+
+hydrostaticStiffness = hydro.hydro_coeffs.linear_restoring_stiffness(dof, dof) * simu.rho * simu.gravity;
+Gi = -((hydro.simulation_parameters.w_extended)'.^2 .* (mass+addedMass)) + 1j * hydro.simulation_parameters.w_extended'.*radiationDamping + hydrostaticStiffness;
+Zi = Gi./(1j*hydro.simulation_parameters.w_extended');
 
 % Calculate magnitude and phase for bode plot
 Mag = 20*log10(abs(Zi));
@@ -40,13 +54,13 @@ Phase = (angle(Zi))*(180/pi);
 
 % Determine natural frequency based on the phase of the impedance
 [~,closestIndNat] = min(abs(imag(Zi)));
-natFreq = hydro.simulation_parameters.w(closestIndNat);
+natFreq = hydro.simulation_parameters.w_extended(closestIndNat);
 natT = (2*pi)/natFreq;
 
 % Create bode plot for impedance
 figure()
 subplot(2,1,1)
-semilogx((hydro.simulation_parameters.w)/(2*pi),Mag)
+semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Mag)
 xlabel('freq (hz)')
 ylabel('mag (dB)')
 grid on
@@ -55,7 +69,7 @@ xline(1/T,'--')
 legend('','Natural Frequency','Wave Frequency','Location','southwest')
 
 subplot(2,1,2)
-semilogx((hydro.simulation_parameters.w)/(2*pi),Phase)
+semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Phase)
 xlabel('freq (hz)')
 ylabel('phase (deg)')
 grid on
@@ -65,10 +79,8 @@ legend('','Natural Frequency','Wave Frequency','Location','northwest')
 
 % Determine optimal latching time
 optLatchTime = 0.5*(T - natT)
-KpOpt = radiationDamping(closestIndOmega)
-force = 80*(mass+addedMass(closestIndOmega))
+KpOpt = radiationDamping(omegaIndex)
+force = 80*(mass+addedMass(omegaIndex))
 
 % Calculate the maximum potential power
 P_max = -sum(abs(Fexc).^2./(8*real(Zi)))
-
-

--- a/Controls/Latching/optimalTimeCalc.m
+++ b/Controls/Latching/optimalTimeCalc.m
@@ -62,7 +62,7 @@ ylabel('mag (dB)')
 grid on
 xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','resonant Frequency','Wave Frequency','Location','southwest')
+legend('','Resonant Frequency','Wave Frequency','Location','southwest')
 
 subplot(2,1,2)
 semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Phase)
@@ -71,7 +71,7 @@ ylabel('phase (deg)')
 grid on
 xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','resonant Frequency','Wave Frequency','Location','northwest')
+legend('','Resonant Frequency','Wave Frequency','Location','northwest')
 
 % Determine optimal latching time
 optLatchTime = 0.5*(T - resonantPeriod)

--- a/Controls/Latching/optimalTimeCalc.m
+++ b/Controls/Latching/optimalTimeCalc.m
@@ -1,6 +1,6 @@
 % This script identifies the dynamics of the float in the respective wave 
-% conditions and determines the optimal proportional gain value for a 
-% passive controller (for regular waves)
+% conditions and determines the optimal proportional gain and latching time
+% value for a regular wave
 
 close all; clear all; clc;
 

--- a/Controls/Passive (P)/optimalGainCalc.m
+++ b/Controls/Passive (P)/optimalGainCalc.m
@@ -8,7 +8,7 @@ dof = 3;            % Caluclate for heave motion
 simu = simulationClass();
 body(1) = bodyClass('../../_Common_Input_Files/Sphere/hydroData/sphere.h5');
 waves.height = 2.5;
-waves.period = 4.5; % One of periods from BEM
+waves.period = 9.6664; % One of periods from BEM
 
 % Load hydrodynamic data for float from BEM
 hydro = readBEMIOH5(body.h5File{1}, 1, body.meanDrift);

--- a/Controls/Passive (P)/optimalGainCalc.m
+++ b/Controls/Passive (P)/optimalGainCalc.m
@@ -1,7 +1,6 @@
 % This script identifies the dynamics of the float in the respective wave 
 % conditions and determines the optimal proportional gain value for a 
 % passive controller (for regular waves)
-
 close all; clear all; clc;
 
 dof = 3;            % Caluclate for heave motion
@@ -9,7 +8,7 @@ dof = 3;            % Caluclate for heave motion
 simu = simulationClass();
 body(1) = bodyClass('../../_Common_Input_Files/Sphere/hydroData/sphere.h5');
 waves.height = 2.5;
-waves.period = 9.6664; % One of periods from BEM
+waves.period = 4.5; % One of periods from BEM
 
 % Load hydrodynamic data for float from BEM
 hydro = readBEMIOH5(body.h5File{1}, 1, body.meanDrift);
@@ -49,10 +48,9 @@ Zi = Gi./(1j*hydro.simulation_parameters.w_extended');
 Mag = 20*log10(abs(Zi));
 Phase = (angle(Zi))*(180/pi);
 
-% Determine natural frequency based on the phase of the impedance
-[~,closestIndNat] = min(abs(imag(Zi)));
-natFreq = hydro.simulation_parameters.w_extended(closestIndNat);
-T0 = (2*pi)/natFreq;
+% Determine resonant frequency based on the phase of the impedance
+resonantFreq = interp1(Phase, hydro.simulation_parameters.w_extended, 0, 'spline','extrap');
+resonantPeriod = (2*pi)/resonantFreq;
 
 % Create bode plot for impedance
 figure()
@@ -61,18 +59,18 @@ semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Mag)
 xlabel('freq (hz)','interpreter','latex')
 ylabel('mag (dB)','interpreter','latex')
 grid on
-xline(natFreq/(2*pi))
+xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','southwest','interpreter','latex')
+legend('','Resonant Frequency','Wave Frequency','Location','southwest','interpreter','latex')
 
 subplot(2,1,2)
 semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Phase)
 xlabel('freq (hz)','interpreter','latex')
 ylabel('phase (deg)','interpreter','latex')
 grid on
-xline(natFreq/(2*pi))
+xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','northwest','interpreter','latex')
+legend('','Resonant Frequency','Wave Frequency','Location','northwest','interpreter','latex')
 
 % Calculate the maximum potential power
 P_max = -sum(abs(Fexc).^2./(8*real(Zi)));

--- a/Controls/Passive (P)/optimalGainCalc.m
+++ b/Controls/Passive (P)/optimalGainCalc.m
@@ -4,9 +4,10 @@
 
 close all; clear all; clc;
 
+dof = 3;            % Caluclate for heave motion
 % Inputs (from wecSimInputFile)
 simu = simulationClass();
-body(1) = bodyClass('../hydroData/sphere.h5');
+body(1) = bodyClass('../../_Common_Input_Files/Sphere/hydroData/sphere.h5');
 waves.height = 2.5;
 waves.period = 9.6664; % One of periods from BEM
 
@@ -19,20 +20,30 @@ A = H/2;
 T = waves.period;
 omega = (1/T)*(2*pi);
 
+% Extend the freq vector to include the wave frequency
+hydro.simulation_parameters.w_extended = sort([hydro.simulation_parameters.w omega]);
+omegaIndex = find(hydro.simulation_parameters.w_extended == omega, 1, 'first');
+
 % Define excitation force based on wave conditions
-ampSpect = zeros(length(hydro.simulation_parameters.w),1);
-[~,closestIndOmega] = min(abs(omega-hydro.simulation_parameters.w));
-ampSpect(closestIndOmega) = A;
-FeRao = squeeze(hydro.hydro_coeffs.excitation.re(3,:))'*simu.rho*simu.gravity + squeeze(hydro.hydro_coeffs.excitation.im(3,:))'*simu.rho*simu.gravity*1j;
-Fexc = ampSpect.*FeRao;
+ampSpect = zeros(length(hydro.simulation_parameters.w_extended),1);
+ampSpect(omegaIndex) = A;
+Fe_re = squeeze(hydro.hydro_coeffs.excitation.re(dof, 1, :)) * simu.rho * simu.gravity;
+Fe_im = squeeze(hydro.hydro_coeffs.excitation.im(dof, 1, :)) * simu.rho * simu.gravity;
+
+Fe_interp = interp1(hydro.simulation_parameters.w, Fe_re + 1j * Fe_im, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+Fexc = ampSpect.*Fe_interp;
 
 % Define the intrinsic mechanical impedance for the device
-mass = simu.rho*hydro.properties.volume;
-addedMass = squeeze(hydro.hydro_coeffs.added_mass.all(3,3,:))*simu.rho;
-radiationDamping = squeeze(hydro.hydro_coeffs.radiation_damping.all(3,3,:)).*squeeze(hydro.simulation_parameters.w')*simu.rho;
-hydrostaticStiffness = hydro.hydro_coeffs.linear_restoring_stiffness(3,3)*simu.rho*simu.gravity;
-Gi = -((hydro.simulation_parameters.w)'.^2.*(mass+addedMass)) + 1j*hydro.simulation_parameters.w'.*radiationDamping + hydrostaticStiffness;
-Zi = Gi./(1j*hydro.simulation_parameters.w');
+mass = simu.rho * hydro.properties.volume;
+addedMass = squeeze(hydro.hydro_coeffs.added_mass.all(dof, dof, :)) * simu.rho;
+addedMass = interp1(hydro.simulation_parameters.w, addedMass, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+
+radiationDamping = squeeze(hydro.hydro_coeffs.radiation_damping.all(dof,dof,:)).*squeeze(hydro.simulation_parameters.w')*simu.rho;
+radiationDamping = interp1(hydro.simulation_parameters.w, radiationDamping, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+
+hydrostaticStiffness = hydro.hydro_coeffs.linear_restoring_stiffness(dof, dof) * simu.rho * simu.gravity;
+Gi = -((hydro.simulation_parameters.w_extended)'.^2 .* (mass+addedMass)) + 1j * hydro.simulation_parameters.w_extended'.*radiationDamping + hydrostaticStiffness;
+Zi = Gi./(1j*hydro.simulation_parameters.w_extended');
 
 % Calculate magnitude and phase for bode plot
 Mag = 20*log10(abs(Zi));
@@ -40,36 +51,39 @@ Phase = (angle(Zi))*(180/pi);
 
 % Determine natural frequency based on the phase of the impedance
 [~,closestIndNat] = min(abs(imag(Zi)));
-natFreq = hydro.simulation_parameters.w(closestIndNat);
+natFreq = hydro.simulation_parameters.w_extended(closestIndNat);
 T0 = (2*pi)/natFreq;
 
 % Create bode plot for impedance
 figure()
 subplot(2,1,1)
-semilogx((hydro.simulation_parameters.w)/(2*pi),Mag)
-xlabel('freq (hz)')
-ylabel('mag (dB)')
+semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Mag)
+xlabel('freq (hz)','interpreter','latex')
+ylabel('mag (dB)','interpreter','latex')
 grid on
 xline(natFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','southwest')
+legend('','Natural Frequency','Wave Frequency','Location','southwest','interpreter','latex')
 
 subplot(2,1,2)
-semilogx((hydro.simulation_parameters.w)/(2*pi),Phase)
-xlabel('freq (hz)')
-ylabel('phase (deg)')
+semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Phase)
+xlabel('freq (hz)','interpreter','latex')
+ylabel('phase (deg)','interpreter','latex')
 grid on
 xline(natFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','northwest')
+legend('','Natural Frequency','Wave Frequency','Location','northwest','interpreter','latex')
 
 % Calculate the maximum potential power
-P_max = -sum(abs(Fexc).^2./(8*real(Zi)))
+P_max = -sum(abs(Fexc).^2./(8*real(Zi)));
+fprintf('Maximum potential power P_max = %f\n', P_max);
 
 % Optimal proportional gain for passive control:
-KpOpt = sqrt(radiationDamping(closestIndOmega)^2 + ((hydrostaticStiffness/omega) - omega*(mass + addedMass(closestIndOmega)))^2)
+KpOpt = sqrt(radiationDamping(omegaIndex)^2 + ((hydrostaticStiffness/omega) - omega*(mass + addedMass(omegaIndex)))^2)
 Ki = 0;
+fprintf('Optimal proportional gain for passive control KpOpt = %f\n', KpOpt);
 
 % Calculate expected power with optimal passive control
 Zpto = KpOpt + Ki/(1j*omega);
-P = -sum(0.5*real(Zpto).*((abs(Fexc)).^2./(abs(Zpto+Zi)).^2))
+P = -sum(0.5*real(Zpto).*((abs(Fexc)).^2./(abs(Zpto+Zi)).^2));
+fprintf('Expected power with optimal passive control P = %f\n', P);

--- a/Controls/Passive (P)/optimalGainCalc.m
+++ b/Controls/Passive (P)/optimalGainCalc.m
@@ -79,7 +79,7 @@ P_max = -sum(abs(Fexc).^2./(8*real(Zi)));
 fprintf('Maximum potential power P_max = %f\n', P_max);
 
 % Optimal proportional gain for passive control:
-KpOpt = sqrt(radiationDamping(omegaIndex)^2 + ((hydrostaticStiffness/omega) - omega*(mass + addedMass(omegaIndex)))^2)
+KpOpt = sqrt(radiationDamping(omegaIndex)^2 + ((hydrostaticStiffness/omega) - omega*(mass + addedMass(omegaIndex)))^2);
 Ki = 0;
 fprintf('Optimal proportional gain for passive control KpOpt = %f\n', KpOpt);
 

--- a/Controls/Passive (P)/optimalGainCalc.m
+++ b/Controls/Passive (P)/optimalGainCalc.m
@@ -36,6 +36,7 @@ Fexc = ampSpect.*Fe_interp;
 mass = simu.rho * hydro.properties.volume;
 addedMass = squeeze(hydro.hydro_coeffs.added_mass.all(dof, dof, :)) * simu.rho;
 addedMass = interp1(hydro.simulation_parameters.w, addedMass, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+addedMass = squeeze(hydro.hydro_coeffs.added_mass.inf_freq(dof, dof, :)) * simu.rho;
 
 radiationDamping = squeeze(hydro.hydro_coeffs.radiation_damping.all(dof,dof,:)).*squeeze(hydro.simulation_parameters.w')*simu.rho;
 radiationDamping = interp1(hydro.simulation_parameters.w, radiationDamping, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
@@ -77,7 +78,7 @@ P_max = -sum(abs(Fexc).^2./(8*real(Zi)));
 fprintf('Maximum potential power P_max = %f\n', P_max);
 
 % Optimal proportional gain for passive control:
-KpOpt = sqrt(radiationDamping(omegaIndex)^2 + ((hydrostaticStiffness/omega) - omega*(mass + addedMass(omegaIndex)))^2);
+KpOpt = sqrt(radiationDamping(omegaIndex)^2 + ((hydrostaticStiffness/omega) - omega*(mass + addedMass))^2);
 Ki = 0;
 fprintf('Optimal proportional gain for passive control KpOpt = %f\n', KpOpt);
 

--- a/Controls/Passive (P)/userDefinedFunctionsMCR.m
+++ b/Controls/Passive (P)/userDefinedFunctionsMCR.m
@@ -17,7 +17,7 @@ mcr.meanForce(imcr) = mean(controllersOutput.force(startInd:endInd,3));
 mcr.maxPower(imcr) = max(controllersOutput.power(startInd:endInd,3));
 mcr.maxForce(imcr) = max(controllersOutput.force(startInd:endInd,3));
 
-if imcr == 9
+if imcr == length(mcr.cases)
     figure()
     plot(mcr.cases,mcr.meanPower)
     title('Mean Power vs. Proportional Gain')

--- a/Controls/Reactive (PI)/optimalGainCalc.m
+++ b/Controls/Reactive (PI)/optimalGainCalc.m
@@ -4,7 +4,6 @@
 close all; clear all; clc;
 
 dof = 3;            % Caluclate for heave motion
-
 % Inputs (from wecSimInputFile)
 simu = simulationClass();
 body(1) = bodyClass('../../_Common_Input_Files/Sphere/hydroData/sphere.h5');
@@ -49,10 +48,9 @@ Zi = Gi./(1j*hydro.simulation_parameters.w_extended');
 Mag = 20*log10(abs(Zi));
 Phase = (angle(Zi))*(180/pi);
 
-% Determine natural frequency based on the phase of the impedance
-[~,closestIndNat] = min(abs(imag(Zi)));
-natFreq = hydro.simulation_parameters.w_extended(closestIndNat);
-T0 = (2*pi)/natFreq;
+% Determine resonant frequency based on the phase of the impedance
+resonantFreq = interp1(Phase, hydro.simulation_parameters.w_extended, 0, 'spline','extrap');
+resonantPeriod = (2*pi)/resonantFreq;
 
 % Create bode plot for impedance
 figure()
@@ -61,18 +59,18 @@ semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Mag)
 xlabel('freq (hz)','interpreter','latex')
 ylabel('mag (dB)','interpreter','latex')
 grid on
-xline(natFreq/(2*pi))
+xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','southwest','interpreter','latex')
+legend('','resonant Frequency','Wave Frequency','Location','southwest','interpreter','latex')
 
 subplot(2,1,2)
 semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Phase)
 xlabel('freq (hz)','interpreter','latex')
 ylabel('phase (deg)','interpreter','latex')
 grid on
-xline(natFreq/(2*pi))
+xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','northwest','interpreter','latex')
+legend('','resonant Frequency','Wave Frequency','Location','northwest','interpreter','latex')
 
 % Calculate the maximum potential power
 P_max = -sum(abs(Fexc).^2./(8*real(Zi)));

--- a/Controls/Reactive (PI)/optimalGainCalc.m
+++ b/Controls/Reactive (PI)/optimalGainCalc.m
@@ -61,7 +61,7 @@ ylabel('mag (dB)','interpreter','latex')
 grid on
 xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','resonant Frequency','Wave Frequency','Location','southwest','interpreter','latex')
+legend('','Resonant Frequency','Wave Frequency','Location','southwest','interpreter','latex')
 
 subplot(2,1,2)
 semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Phase)
@@ -70,7 +70,7 @@ ylabel('phase (deg)','interpreter','latex')
 grid on
 xline(resonantFreq/(2*pi))
 xline(1/T,'--')
-legend('','resonant Frequency','Wave Frequency','Location','northwest','interpreter','latex')
+legend('','Resonant Frequency','Wave Frequency','Location','northwest','interpreter','latex')
 
 % Calculate the maximum potential power
 P_max = -sum(abs(Fexc).^2./(8*real(Zi)));

--- a/Controls/Reactive (PI)/optimalGainCalc.m
+++ b/Controls/Reactive (PI)/optimalGainCalc.m
@@ -1,10 +1,13 @@
 % This script identifies the dynamics of the float in the respective wave 
 % conditions and determines the optimal proportional gain value for a 
-% passive controller (for regular waves)
+% reactive controller (for regular waves)
+close all; clear all; clc;
+
+dof = 3;            % Caluclate for heave motion
 
 % Inputs (from wecSimInputFile)
 simu = simulationClass();
-body(1) = bodyClass('../hydroData/sphere.h5');
+body(1) = bodyClass('../../_Common_Input_Files/Sphere/hydroData/sphere.h5');
 waves.height = 2.5;
 waves.period = 9.6664;
 
@@ -17,20 +20,30 @@ A = H/2;
 T = waves.period;
 omega = (1/T)*(2*pi);
 
+% Extend the freq vector to include the wave frequency
+hydro.simulation_parameters.w_extended = sort([hydro.simulation_parameters.w omega]);
+omegaIndex = find(hydro.simulation_parameters.w_extended == omega, 1, 'first');
+
 % Define excitation force based on wave conditions
-ampSpect = zeros(length(hydro.simulation_parameters.w),1);
-[~,closestIndOmega] = min(abs(omega-hydro.simulation_parameters.w));
-ampSpect(closestIndOmega) = A;
-FeRao = squeeze(hydro.hydro_coeffs.excitation.re(3,:))'*simu.rho*simu.gravity + squeeze(hydro.hydro_coeffs.excitation.im(3,:))'*simu.rho*simu.gravity*1j;
-Fexc = ampSpect.*FeRao;
+ampSpect = zeros(length(hydro.simulation_parameters.w_extended),1);
+ampSpect(omegaIndex) = A;
+Fe_re = squeeze(hydro.hydro_coeffs.excitation.re(dof, 1, :)) * simu.rho * simu.gravity;
+Fe_im = squeeze(hydro.hydro_coeffs.excitation.im(dof, 1, :)) * simu.rho * simu.gravity;
+
+Fe_interp = interp1(hydro.simulation_parameters.w, Fe_re + 1j * Fe_im, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+Fexc = ampSpect.*Fe_interp;
 
 % Define the intrinsic mechanical impedance for the device
-mass = simu.rho*hydro.properties.volume;
-addedMass = squeeze(hydro.hydro_coeffs.added_mass.all(3,3,:))*simu.rho;
-radiationDamping = squeeze(hydro.hydro_coeffs.radiation_damping.all(3,3,:)).*squeeze(hydro.simulation_parameters.w')*simu.rho;
-hydrostaticStiffness = hydro.hydro_coeffs.linear_restoring_stiffness(3,3)*simu.rho*simu.gravity;
-Gi = -((hydro.simulation_parameters.w)'.^2.*(mass+addedMass)) + 1j*hydro.simulation_parameters.w'.*radiationDamping + hydrostaticStiffness;
-Zi = Gi./(1j*hydro.simulation_parameters.w');
+mass = simu.rho * hydro.properties.volume;
+addedMass = squeeze(hydro.hydro_coeffs.added_mass.all(dof, dof, :)) * simu.rho;
+addedMass = interp1(hydro.simulation_parameters.w, addedMass, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+
+radiationDamping = squeeze(hydro.hydro_coeffs.radiation_damping.all(dof,dof,:)).*squeeze(hydro.simulation_parameters.w')*simu.rho;
+radiationDamping = interp1(hydro.simulation_parameters.w, radiationDamping, hydro.simulation_parameters.w_extended, 'spline', 'extrap')';
+
+hydrostaticStiffness = hydro.hydro_coeffs.linear_restoring_stiffness(dof, dof) * simu.rho * simu.gravity;
+Gi = -((hydro.simulation_parameters.w_extended)'.^2 .* (mass+addedMass)) + 1j * hydro.simulation_parameters.w_extended'.*radiationDamping + hydrostaticStiffness;
+Zi = Gi./(1j*hydro.simulation_parameters.w_extended');
 
 % Calculate magnitude and phase for bode plot
 Mag = 20*log10(abs(Zi));
@@ -38,35 +51,39 @@ Phase = (angle(Zi))*(180/pi);
 
 % Determine natural frequency based on the phase of the impedance
 [~,closestIndNat] = min(abs(imag(Zi)));
-natFreq = hydro.simulation_parameters.w(closestIndNat);
+natFreq = hydro.simulation_parameters.w_extended(closestIndNat);
 T0 = (2*pi)/natFreq;
 
 % Create bode plot for impedance
 figure()
 subplot(2,1,1)
-semilogx((hydro.simulation_parameters.w)/(2*pi),Mag)
-xlabel('freq (hz)')
-ylabel('mag (dB)')
+semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Mag)
+xlabel('freq (hz)','interpreter','latex')
+ylabel('mag (dB)','interpreter','latex')
 grid on
 xline(natFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','southwest')
+legend('','Natural Frequency','Wave Frequency','Location','southwest','interpreter','latex')
 
 subplot(2,1,2)
-semilogx((hydro.simulation_parameters.w)/(2*pi),Phase)
-xlabel('freq (hz)')
-ylabel('phase (deg)')
+semilogx((hydro.simulation_parameters.w_extended)/(2*pi),Phase)
+xlabel('freq (hz)','interpreter','latex')
+ylabel('phase (deg)','interpreter','latex')
 grid on
 xline(natFreq/(2*pi))
 xline(1/T,'--')
-legend('','Natural Frequency','Wave Frequency','Location','northwest')
+legend('','Natural Frequency','Wave Frequency','Location','northwest','interpreter','latex')
 
 % Calculate the maximum potential power
-P_max = -sum(abs(Fexc).^2./(8*real(Zi)))
+P_max = -sum(abs(Fexc).^2./(8*real(Zi)));
+fprintf('Maximum potential power P_max = %f\n', P_max);
 
 % Calculate optimal Kp and Ki gains for reactive control
-KpOpt = radiationDamping(closestIndOmega)
-KiOpt = -(-omega^2*(mass + addedMass(closestIndOmega)) + hydrostaticStiffness)
+KpOpt = radiationDamping(omegaIndex);
+KiOpt = -(-omega^2*(mass + addedMass(omegaIndex)) + hydrostaticStiffness);
+fprintf('Optimal gains for reactive control Kp = %f and Ki = %f\n', KpOpt, KiOpt);
 
+% Calculate expected power with optimal reactive control
 Zpto = KpOpt + KiOpt/(1j*omega);
-P = -sum(0.5*real(Zpto).*((abs(Fexc)).^2./(abs(Zpto+Zi)).^2))
+P = -sum(0.5*real(Zpto).*((abs(Fexc)).^2./(abs(Zpto+Zi)).^2));
+fprintf('Expected power with optimal passive control P = %f\n', P);

--- a/Controls/Reactive (PI)/userDefinedFunctionsMCR.m
+++ b/Controls/Reactive (PI)/userDefinedFunctionsMCR.m
@@ -17,7 +17,7 @@ mcr.meanForce(imcr) = mean(controllersOutput.force(startInd:endInd,3));
 mcr.maxPower(imcr) = max(controllersOutput.power(startInd:endInd,3));
 mcr.maxForce(imcr) = max(controllersOutput.force(startInd:endInd,3));
 
-if imcr == 81
+if imcr == length(mcr.cases)
 
     % Kp and Ki gains
     kps = unique(mcr.cases(:,1));


### PR DESCRIPTION
 This PR updates the `optimalGainCalc` files for the P and PI controllers to compute the gains and power using interpolated hydrodynamic coefficients instead of relying on the values at the nearest frequency.

**Benefit:**
Interpolating the hydrodynamic coefficients improves the accuracy of the computed gains and power, especially when the hydrodynamic data is available only at coarse frequency intervals.

Below are a comparison of the codes results before (-- orange) and after the modification (blue)
**PI:** 
<img width="331" height="255" alt="image" src="https://github.com/user-attachments/assets/32dae7d1-397e-4fdf-90bf-9904afda3e33" />

**P:**  
<img width="323" height="249" alt="image" src="https://github.com/user-attachments/assets/0bb0d20c-a810-45a6-9de4-962692fa16dc" />


