### PR TITLE
Update testing suite

### DIFF
--- a/.github/workflows/all-tests-reusable.yml
+++ b/.github/workflows/all-tests-reusable.yml
@@ -20,16 +20,16 @@ jobs:
     steps:
       - run: echo "Triggered by WEC-Sim commit ${{ fromJSON(inputs.client_payload).sha }}"
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: true
           ref: ${{ fromJSON(inputs.client_payload).branch }}
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
           release: R2024b
       - name: Get test target folder
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         with:
           command: getTestTargets
       - name: Save output

--- a/.github/workflows/changed-tests.yml
+++ b/.github/workflows/changed-tests.yml
@@ -24,22 +24,22 @@ jobs:
     if: github.event_name != 'repository_dispatch'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: true
           fetch-depth: 0
       - name: Generate git diff
-        uses: GrantBirki/git-diff-action@v2
+        uses: GrantBirki/git-diff-action@v3
         id: git-diff-action
         with:
           json_diff_file_output: diff.json
           file_output_only: "true"
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
           release: R2024b
       - name: Get test target folder
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         with:
           command: getTestTargets("diff.json")
       - name: Save output

--- a/.github/workflows/run-tests-reusable.yml
+++ b/.github/workflows/run-tests-reusable.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           lfs: true
           ref: ${{ inputs.head_ref }}
@@ -41,14 +41,14 @@ jobs:
       - name: Checkout LFS objects
         run: git lfs checkout
       - name: Check out WEC-Sim
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: WEC-Sim/WEC-Sim
           ref: ${{ inputs.base_ref }}
           path: './WEC-Sim'
       - name: Check out MoorDyn
         if: matrix.folder == 'Mooring' || matrix.folder == 'OWC' || matrix.folder == 'Paraview_Visualization'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: WEC-Sim/MoorDyn
           path: './MoorDyn'
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         working-directory: './MoorDyn'
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
         with:
           products: ${{ matrix.products }}
           release: ${{ matrix.release }}
@@ -71,7 +71,7 @@ jobs:
           Xvfb :99 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
       - name: Install WEC-Sim, run tests and generate artifacts
-        uses: matlab-actions/run-command@v2
+        uses: matlab-actions/run-command@v3
         with:
           command: |
             addpath(genpath('WEC-Sim/source'));

--- a/Body-to-Body_Interactions/TestB2B.m
+++ b/Body-to-Body_Interactions/TestB2B.m
@@ -21,6 +21,14 @@ classdef TestB2B < matlab.unittest.TestCase
     end
     
     methods(TestClassSetup)
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end

--- a/Cable/TestCable.m
+++ b/Cable/TestCable.m
@@ -22,11 +22,17 @@ classdef TestCable < matlab.unittest.TestCase
     end
     
     methods(TestClassSetup)
-        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0, 'DefaultFigureVisible');
         end
-        
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -40,18 +46,17 @@ classdef TestCable < matlab.unittest.TestCase
     end
     
     methods(TestClassTeardown)
-        
         function checkVisibilityRestored(testCase)
             set(0, 'DefaultFigureVisible', testCase.OriginalDefault);
             testCase.assertEqual(get(0, 'DefaultFigureVisible'),    ...
                                  testCase.OriginalDefault);
         end
-        
     end
     
     methods(Test)
         function testCable(testCase)
             wecSim
+            close_system('MBARI_cable',0)
         end
     end
     

--- a/Controls/TestControls.m
+++ b/Controls/TestControls.m
@@ -24,6 +24,14 @@ classdef TestControls < matlab.unittest.TestCase
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -53,26 +61,32 @@ classdef TestControls < matlab.unittest.TestCase
         function testPassive(testCase)
             cd('Passive (P)')
             wecSim
+            close_system('passive',0)
         end        
         function testReactive(testCase)
             cd('Reactive (PI)')
             wecSim
+            close_system('reactive',0)
         end        
         function testLatching(testCase)
             cd('Latching')
             wecSim
+            close_system('latchTime',0)
         end        
         function testDeclutching(testCase)
             cd('Declutching')
             wecSim
+            close_system('declutch',0)
         end        
         function testMPC(testCase)
             cd('MPC')
             wecSim
+            close_system('sphereMPC',0)
         end     
         function testReactiveWithPTO(testCase)
             cd('ReactiveWithPTO')
             wecSim
+            close_system('reactiveWithPTO',0)
         end     
     end    
 end

--- a/Desalination/TestDesalination.m
+++ b/Desalination/TestDesalination.m
@@ -24,7 +24,15 @@ classdef TestDesalination < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end   
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end     
         function runBemio(testCase)            
             % Check for Simscape Fluids
             assumeEqual(testCase,                               ...
@@ -38,7 +46,7 @@ classdef TestDesalination < matlab.unittest.TestCase
             end
             cd(testCase.testDir)            
             testCase.hasH5 = true;            
-        end        
+        end
     end
     
     methods(TestClassTeardown)        
@@ -52,6 +60,7 @@ classdef TestDesalination < matlab.unittest.TestCase
     methods(Test)        
         function testDesalination(testCase)
             wecSim
+            close_system('OSWEC_RO',0)
         end        
     end    
 end

--- a/End_Stops/TestEndStops.m
+++ b/End_Stops/TestEndStops.m
@@ -23,7 +23,15 @@ classdef TestEndStops < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -34,7 +42,7 @@ classdef TestEndStops < matlab.unittest.TestCase
             cd(testCase.testDir)            
         end        
     end
-    
+
     methods(TestClassTeardown)        
         function checkVisibilityRestored(testCase)
             set(0,'DefaultFigureVisible',testCase.OriginalDefault);
@@ -46,6 +54,7 @@ classdef TestEndStops < matlab.unittest.TestCase
     methods(Test)        
         function testEnd_Stops(testCase)
             wecSim
+            close_system('RM3',0)
         end        
     end    
 end

--- a/Free_Decay/TestFreeDecay.m
+++ b/Free_Decay/TestFreeDecay.m
@@ -23,7 +23,15 @@ classdef TestFreeDecay < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)

--- a/Full_Directional_Waves/TestFullDirectionalWaves.m
+++ b/Full_Directional_Waves/TestFullDirectionalWaves.m
@@ -23,7 +23,15 @@ classdef TestFullDirectionalWaves < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -52,6 +60,7 @@ classdef TestFullDirectionalWaves < matlab.unittest.TestCase
     methods(Test)        
         function testFullDirectionalWaves(testCase)
             wecSim
-        end               
+            close_system('OSWEC',0)
+        end
     end    
 end

--- a/Generalized_Body_Modes/TestGeneralizedBodyModes.m
+++ b/Generalized_Body_Modes/TestGeneralizedBodyModes.m
@@ -23,7 +23,15 @@ classdef TestGeneralizedBodyModes < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -46,6 +54,7 @@ classdef TestGeneralizedBodyModes < matlab.unittest.TestCase
     methods(Test)        
         function testGeneralized_Body_Modes(testCase)
             wecSim
+            close_system('GBM',0)
         end        
     end    
 end

--- a/Load_Mitigating_Controls/TestLoadMitigatingControls.m
+++ b/Load_Mitigating_Controls/TestLoadMitigatingControls.m
@@ -22,7 +22,15 @@ classdef TestLoadMitigatingControls < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -52,14 +60,17 @@ classdef TestLoadMitigatingControls < matlab.unittest.TestCase
         function testLoad_Mitigating_Control_ControlTests(testCase)
             cd('ControlTests')
             wecSim
+            close_system('WaveBot3Dof_Control',0)
         end
         function testLoad_Mitigating_Control_CalcImpedance(testCase)
             cd('CalcImpedance')
             wecSim
+            close_system('WaveBot3Dof_ID',0)
         end
         function testLoad_Mitigating_Control_CalcImpedance_MCR(testCase)
             cd('CalcImpedance')
             wecSimMCR
+            close_system('WaveBot3Dof_ID',0)
         end
     end
 end

--- a/MOST/tests/TestMOST.m
+++ b/MOST/tests/TestMOST.m
@@ -73,9 +73,6 @@ classdef TestMOST < matlab.unittest.TestCase
                 plotTests(testCase.turbulent.newCase,testCase.turbulent.orgCase);
             end
         end
-        function closeModels(~)
-            bdclose('all');
-        end
         function checkVisibilityRestored(testCase)
             set(0,'DefaultFigureVisible',testCase.OriginalDefault);
             testCase.assertEqual(get(0,'DefaultFigureVisible'),...

--- a/MOST/tests/TestMOST.m
+++ b/MOST/tests/TestMOST.m
@@ -33,6 +33,14 @@ classdef TestMOST < matlab.unittest.TestCase
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBEMIO(testCase)
             cd(fullfile(testCase.testDir, testCase.hydroDataDir));
             if isfile(testCase.h5Name)
@@ -52,6 +60,7 @@ classdef TestMOST < matlab.unittest.TestCase
         function runTurbulentTest(testCase)
             cd(fullfile(testCase.testDir,'turbulent'))
             runLoadTurbulent;
+            close_system('SModel_VolturnUS',0)
             testCase.turbulent = load('turbulent.mat').("turbulent");
             cd(testCase.testDir);
         end
@@ -63,6 +72,9 @@ classdef TestMOST < matlab.unittest.TestCase
             if testCase.plotComparison == 1
                 plotTests(testCase.turbulent.newCase,testCase.turbulent.orgCase);
             end
+        end
+        function closeModels(~)
+            bdclose('all');
         end
         function checkVisibilityRestored(testCase)
             set(0,'DefaultFigureVisible',testCase.OriginalDefault);

--- a/Mean_Drift/TestMeanDrift.m
+++ b/Mean_Drift/TestMeanDrift.m
@@ -21,12 +21,18 @@ classdef TestMeanDrift < matlab.unittest.TestCase
         end
     end
     
-    methods(TestClassSetup)        
-        
+    methods(TestClassSetup)
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end
-        
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -36,22 +42,20 @@ classdef TestMeanDrift < matlab.unittest.TestCase
             end
             cd(testCase.testDir)            
         end
-        
-    end    
+    end
     
     methods(TestClassTeardown)
-        
         function checkVisibilityRestored(testCase)
             set(0,'DefaultFigureVisible',testCase.OriginalDefault);
             testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
                                  testCase.OriginalDefault);
-        end       
-        
+        end
     end
     
     methods(Test)        
         function testMean_Drift(testCase)
             wecSim
+            close_system('sphere',0)
         end        
     end
     

--- a/Mooring/TestMooring.m
+++ b/Mooring/TestMooring.m
@@ -23,7 +23,15 @@ classdef TestMooring < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)

--- a/Morison_Element/TestMorisonElement.m
+++ b/Morison_Element/TestMorisonElement.m
@@ -20,10 +20,18 @@ classdef TestMorisonElement < matlab.unittest.TestCase
         end        
     end
     
-    methods(TestClassSetup)        
+    methods(TestClassSetup)
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -38,7 +46,7 @@ classdef TestMorisonElement < matlab.unittest.TestCase
     methods(TestMethodTeardown)
         function returnHome(testCase)
             cd(testCase.testDir)
-        end        
+        end
     end
     
     methods(TestClassTeardown)

--- a/Multiple_Condition_Runs/TestMultipleConditionRuns.m
+++ b/Multiple_Condition_Runs/TestMultipleConditionRuns.m
@@ -23,7 +23,15 @@ classdef TestMultipleConditionRuns < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)

--- a/Multiple_Wave_Spectra/TestMultipleWaveSpectra.m
+++ b/Multiple_Wave_Spectra/TestMultipleWaveSpectra.m
@@ -22,11 +22,17 @@ classdef TestMultipleWaveHeadings < matlab.unittest.TestCase
     end
     
     methods(TestClassSetup)
-        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end
-        
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -44,12 +50,13 @@ classdef TestMultipleWaveHeadings < matlab.unittest.TestCase
             set(0,'DefaultFigureVisible',testCase.OriginalDefault);
             testCase.assertEqual(get(0,'DefaultFigureVisible'),     ...
                                  testCase.OriginalDefault);
-        end        
+        end
     end
     
     methods(Test)        
         function testMultiple_Wave_Headings(testCase)
             wecSim
+            close_system('OSWEC',0)
         end        
     end    
 end

--- a/Nonhydro_Body/TestNonHydroBody.m
+++ b/Nonhydro_Body/TestNonHydroBody.m
@@ -24,7 +24,14 @@ classdef TestNonHydroBody < matlab.unittest.TestCase
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end
-        
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -48,6 +55,7 @@ classdef TestNonHydroBody < matlab.unittest.TestCase
     methods(Test)        
         function testNonhydro_Body(testCase)
             wecSim
+            close_system('OSWEC',0)
         end        
     end
     

--- a/Nonlinear_Hydro/TestNonlinearHydro.m
+++ b/Nonlinear_Hydro/TestNonlinearHydro.m
@@ -23,7 +23,15 @@ classdef TestNonlinearHydro < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -59,16 +67,16 @@ classdef TestNonlinearHydro < matlab.unittest.TestCase
             cd(fullfile('ode4', 'RegularCIC'))
             wecSim
             close_system('ellipsoid',0)
-        end        
+        end
         function testNonlinear_Hydro_ode45_Regular(testCase)
             cd(fullfile('ode45', 'Regular'))
             wecSim
             close_system('ellipsoid',0)
-        end        
+        end
         function testNonlinear_Hydro_ode45_RegularCIC(testCase)
             cd(fullfile('ode45', 'RegularCIC'))
             wecSim
             close_system('ellipsoid',0)
-        end        
+        end
     end    
 end

--- a/OWC/TestOWC.m
+++ b/OWC/TestOWC.m
@@ -22,6 +22,14 @@ classdef TestOWC < matlab.unittest.TestCase
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemioOrifice(testCase)
             cd(testCase.h5DirOrifice);
             if isfile(testCase.h5NameOrifice)
@@ -58,7 +66,7 @@ classdef TestOWC < matlab.unittest.TestCase
         function testOWCOrifice(testCase)
             cd('OrificeModel')
             wecSim
-            close_system('OWC_rigid',0)
+            close_system('OWC_GBM',0)
         end
         function testOWCFloating(testCase)
             isCI = strcmpi(getenv("GITHUB_ACTIONS"), "true");
@@ -67,7 +75,7 @@ classdef TestOWC < matlab.unittest.TestCase
                 "MoorDyn is not installed");
             cd('FloatingOWC')
             wecSim
-            close_system('OWC_GBM',0)
+            close_system('OWC_rigid',0)
         end
     end
 end

--- a/PTO-Sim/OSWEC/TestPTOSimOSWEC.m
+++ b/PTO-Sim/OSWEC/TestPTOSimOSWEC.m
@@ -23,7 +23,15 @@ classdef TestPTOSimOSWEC < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -58,10 +66,12 @@ classdef TestPTOSimOSWEC < matlab.unittest.TestCase
         function testOSWEC_Hydraulic_Crank_PTO(testCase)
             cd('OSWEC_Hydraulic_Crank_PTO')
             wecSim
+            close_system('OSWEC_Hydraulic_Crank_PTO',0)
         end        
         function testOSWEC_Hydraulic_PTO(testCase)
             cd('OSWEC_Hydraulic_PTO')
             wecSim
+            close_system('OSWEC_Hydraulic_PTO',0)
         end        
     end    
 end

--- a/PTO-Sim/RM3/TestPTOSimRM3.m
+++ b/PTO-Sim/RM3/TestPTOSimRM3.m
@@ -23,7 +23,15 @@ classdef TestPTOSimRM3 < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -58,10 +66,12 @@ classdef TestPTOSimRM3 < matlab.unittest.TestCase
         function testRM3_cHydraulic_PTO(testCase)
             cd('RM3_cHydraulic_PTO')
             wecSim
+            close_system('RM3_cHydraulic_PTO',0)
         end        
         function testRM3_DD_PTO(testCase)
             cd('RM3_DD_PTO')
             wecSim
+            close_system('RM3_DD_PTO',0)
         end               
     end    
 end

--- a/Paraview_Visualization/OSWEC_NonLinear_Viz/TestOSWECNonLinearViz.m
+++ b/Paraview_Visualization/OSWEC_NonLinear_Viz/TestOSWECNonLinearViz.m
@@ -24,6 +24,14 @@ classdef TestOSWECNonLinearViz < matlab.unittest.TestCase
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -54,6 +62,7 @@ classdef TestOSWECNonLinearViz < matlab.unittest.TestCase
     methods(Test)        
         function testParaview_Visualization_OSWEC_NonLinear_Viz(testCase)
             wecSim
+            close_system('OSWEC',0)
         end        
     end    
 end

--- a/Paraview_Visualization/RM3_MoorDyn_Viz/TestMoorDynViz.m
+++ b/Paraview_Visualization/RM3_MoorDyn_Viz/TestMoorDynViz.m
@@ -25,6 +25,14 @@ classdef TestMoorDynViz < matlab.unittest.TestCase
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             % Check for MoorDyn
             assumeEqual(testCase,                           ...
@@ -65,6 +73,7 @@ classdef TestMoorDynViz < matlab.unittest.TestCase
             isCI = strcmpi(getenv("GITHUB_ACTIONS"), "true");
             testCase.assumeFalse(isCI, "Skipping MoorDyn test on GitHub CI");
             wecSim
+            close_system('RM3MoorDyn',0)
         end        
     end    
 end

--- a/Passive_Yaw/TestPassiveYaw.m
+++ b/Passive_Yaw/TestPassiveYaw.m
@@ -21,6 +21,14 @@ classdef TestPassiveYaw < matlab.unittest.TestCase
     end
     
     methods(TestClassSetup)
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end

--- a/Passive_Yaw/TestPassiveYawRegression.m
+++ b/Passive_Yaw/TestPassiveYawRegression.m
@@ -28,6 +28,14 @@ classdef TestPassiveYawRegression < matlab.unittest.TestCase
     end
     
     methods(TestClassSetup)
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runYawIrrTest(testCase)
             cd(fullfile(testCase.testDir,   ...
                         'PassiveYawRegression'))

--- a/RM3_PTO_Extension/TestRM3PTOExtension.m
+++ b/RM3_PTO_Extension/TestRM3PTOExtension.m
@@ -23,7 +23,15 @@ classdef TestRM3PTOExtension < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)

--- a/Radiation_Force_Options/TestRadiationForceOptions.m
+++ b/Radiation_Force_Options/TestRadiationForceOptions.m
@@ -22,11 +22,17 @@ classdef TestRadiationForceOptions < matlab.unittest.TestCase
     end
     
     methods(TestClassSetup)
-
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end
-
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -52,6 +58,7 @@ classdef TestRadiationForceOptions < matlab.unittest.TestCase
     methods(Test)        
         function TestRadiation_Force_Options(testCase)
             compare_runs
+            close_system('RM3',0)
         end               
     end 
 

--- a/Radiation_Force_Options/compare_runs.m
+++ b/Radiation_Force_Options/compare_runs.m
@@ -8,6 +8,7 @@ enable_FIR         = 0;
 enable_ss          = 0;
 t_regular          = tic;
 wecSim
+close_system('RM3',0)
 run_time.baseline    = toc(t_regular);
 run_summary.baseline = output;
 clearvars -except run_summary run_time
@@ -19,6 +20,7 @@ enable_FIR         = 1;
 enable_ss          = 0;
 tStart_FIR = tic;
 wecSim
+close_system('RM3',0)
 run_time.FIR    = toc(tStart_FIR)/run_time.baseline;
 run_summary.FIR = output;
 clearvars -except run_summary run_time
@@ -30,6 +32,7 @@ enable_FIR         = 0;
 enable_ss          = 1;
 tStart_ss          = tic;
 wecSim
+close_system('RM3',0)
 run_time.state_space   = toc(tStart_ss)/run_time.baseline;
 run_summary.state_space = output;
 clearvars -except run_summary run_time
@@ -40,6 +43,7 @@ enable_FIR         = 0;
 enable_ss          = 0;
 t_conv             = tic;
 wecSim
+close_system('RM3',0)
 run_time.convolution    = toc(t_conv)/run_time.baseline;
 run_summary.convolution = output;
 clearvars -except run_summary run_time

--- a/Variable_Hydro/TestVariableHydro.m
+++ b/Variable_Hydro/TestVariableHydro.m
@@ -24,11 +24,17 @@ classdef TestVariableHydro < matlab.unittest.TestCase
     end
     
     methods(TestClassSetup)
-        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0, 'DefaultFigureVisible');
         end
-        
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemioPY(testCase)
             cd(testCase.h5DirPY);
             if isfile(testCase.h5NamePY)
@@ -74,7 +80,7 @@ classdef TestVariableHydro < matlab.unittest.TestCase
         function testVM(testCase)
             cd('Variable_Mass')
             wecSim
-            close_system('OSWEC',0)
+            close_system('sphereVarMass',0)
         end
     end
     

--- a/WECCCOMP/TestWECCCOMP.m
+++ b/WECCCOMP/TestWECCCOMP.m
@@ -23,7 +23,15 @@ classdef TestWECCCOMP < matlab.unittest.TestCase
     methods(TestClassSetup)        
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
-        end        
+        end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)            
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)

--- a/Wave_Markers/TestWaveMarkerRM3.m
+++ b/Wave_Markers/TestWaveMarkerRM3.m
@@ -24,6 +24,14 @@ classdef TestWaveMarkerRM3 < matlab.unittest.TestCase
         function captureVisibility(testCase)
             testCase.OriginalDefault = get(0,'DefaultFigureVisible');
         end
+        function removeProjectFolder(~)
+            d = dir('**');
+            d = d([d.isdir]);
+            d = d(string({d.name})=="slprj");
+            for i = 1:length(d)
+                rmdir(fullfile(d(i).folder, d(i).name), 's')
+            end
+        end
         function runBemio(testCase)
             cd(testCase.h5Dir);
             if isfile(testCase.h5Name)
@@ -47,6 +55,7 @@ classdef TestWaveMarkerRM3 < matlab.unittest.TestCase
         function testRM3_Marker(testCase)
             cd RM3
             wecSim
+            close_system('RM3',0)
         end               
     end    
 end


### PR DESCRIPTION
This PR:
- [x] adds a setup job to every test that removes the `slprj` folder so that tests can be rerun most robustly locally when multiple matlab versions are being used
- [x] updates the versions of GitHub Actions to the current releases
- [x] adds calls to `close_system` and closes each simulink model after running so that there are no naming conflicts as the entire test suite runs